### PR TITLE
Release v2.6.4

### DIFF
--- a/.github/scripts/mcp-smoke.mjs
+++ b/.github/scripts/mcp-smoke.mjs
@@ -14,7 +14,7 @@
  *
  * Env:
  *   MCP_COMMAND   기본 "npx"
- *   MCP_ARGS      기본 "-y @weppy/roblox-mcp"  (공백 분리)
+ *   MCP_ARGS      기본 "-y @weppy/roblox-mcp@latest"  (공백 분리)
  *   MCP_TIMEOUT   기본 60000 (ms)
  */
 
@@ -22,7 +22,10 @@ import { spawn } from 'node:child_process';
 import { once } from 'node:events';
 
 const COMMAND = process.env.MCP_COMMAND || 'npx';
-const ARGS = (process.env.MCP_ARGS || '-y @weppy/roblox-mcp').split(/\s+/).filter(Boolean);
+// Default to `@latest` so npx is forced to resolve from the registry instead of
+// reusing whatever stale version sits in the runner's npm cache (the v2.0.8
+// regression that users hit when bare `@weppy/roblox-mcp` was published).
+const ARGS = (process.env.MCP_ARGS || '-y @weppy/roblox-mcp@latest').split(/\s+/).filter(Boolean);
 const TIMEOUT_MS = Number(process.env.MCP_TIMEOUT || 60_000);
 
 console.log(`[smoke] launching: ${COMMAND} ${ARGS.join(' ')}`);

--- a/.github/workflows/install-test.yml
+++ b/.github/workflows/install-test.yml
@@ -116,15 +116,17 @@ jobs:
           $stubDir = Join-Path $env:RUNNER_TEMP 'codex-stub'
           New-Item -ItemType Directory -Path $stubDir -Force | Out-Null
 
+          # Use $StubArgs (not $Args) — $Args is an automatic PowerShell variable
+          # and binding it via param triggers a parameter-binding error on pwsh 7.
           $stubPs1 = @'
-          param([Parameter(ValueFromRemainingArguments = $true)] [string[]] $Args)
-          if ($Args.Count -ge 2 -and $Args[0] -eq 'mcp' -and $Args[1] -eq 'add') {
-            $rest = $Args[2..($Args.Count - 1)]
+          param([Parameter(ValueFromRemainingArguments = $true)] [string[]] $StubArgs)
+          if ($null -ne $StubArgs -and $StubArgs.Count -ge 2 -and $StubArgs[0] -eq 'mcp' -and $StubArgs[1] -eq 'add') {
+            $rest = $StubArgs[2..($StubArgs.Count - 1)]
             $name = $rest[0]
             $idx = 1
             if ($rest.Count -gt 1 -and $rest[1] -eq '--') { $idx = 2 }
             $cmd = $rest[$idx]
-            $cmdArgs = $rest[($idx + 1)..($rest.Count - 1)]
+            $cmdArgs = if (($idx + 1) -lt $rest.Count) { $rest[($idx + 1)..($rest.Count - 1)] } else { @() }
             $argsJson = ($cmdArgs | ForEach-Object { '"' + $_ + '"' }) -join ', '
             $codexDir = Join-Path $env:USERPROFILE '.codex'
             New-Item -ItemType Directory -Path $codexDir -Force | Out-Null


### PR DESCRIPTION
## Release v2.6.4


### Bug Fixes

- **Fix MCP server crashing on startup** — The MCP server could crash immediately on startup, preventing any tools from loading. The server now starts cleanly without any config change.

---
Automated release from weppy-roblox-mcp-private