### PR TITLE
Release v2.6.4

### DIFF
--- a/.github/scripts/mcp-smoke.mjs
+++ b/.github/scripts/mcp-smoke.mjs
@@ -30,9 +30,13 @@ const TIMEOUT_MS = Number(process.env.MCP_TIMEOUT || 60_000);
 
 console.log(`[smoke] launching: ${COMMAND} ${ARGS.join(' ')}`);
 
+// On Windows, `npx` resolves to `npx.cmd`, and Node's spawn() does not consult
+// PATHEXT — without shell:true it fails with ENOENT. Routing through a shell
+// works uniformly on every OS.
 const child = spawn(COMMAND, ARGS, {
   stdio: ['pipe', 'pipe', 'pipe'],
   env: { ...process.env, NODE_ENV: 'production' },
+  shell: true,
 });
 
 let exited = false;


### PR DESCRIPTION
## Release v2.6.4


### Bug Fixes

- **Fix MCP server crashing on startup** — The MCP server could crash immediately on startup, preventing any tools from loading. The server now starts cleanly without any config change.

---
Automated release from weppy-roblox-mcp-private