### PR TITLE
Release v2.7.7

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,15 +1,26 @@
 {
   "name": "hope1026-roblox-mcp",
+  "interface": {
+    "displayName": "WEPPY Roblox AI Toolkit"
+  },
   "metadata": {
-    "description": "WEPPY Roblox MCP — WEPPY AI Agent Plugin and MCP setup for live Roblox Studio workflows with direct Studio control, sync, playtest, UI Studio, and dashboard monitoring",
-    "version": "2.7.6"
+    "description": "WEPPY Roblox AI Toolkit — AI Agent Plugin and MCP setup for live Roblox Studio workflows with direct Studio control, sync, playtest, UI Studio, and dashboard monitoring",
+    "version": "2.7.7"
   },
   "plugins": [
     {
-      "name": "weppy-roblox-mcp",
-      "source": "./plugins/weppy-roblox-mcp",
-      "description": "WEPPY Roblox MCP setup for Codex.",
-      "version": "2.7.6"
+      "name": "weppy-roblox-ai-toolkit",
+      "source": {
+        "source": "local",
+        "path": "./plugins/weppy-roblox-mcp"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Coding",
+      "description": "WEPPY Roblox AI Toolkit setup for Codex.",
+      "version": "2.7.7"
     }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,15 +5,15 @@
     "email": "hope841026@gmail.com"
   },
   "metadata": {
-    "description": "WEPPY Roblox MCP — WEPPY AI Agent Plugin and MCP setup for live Roblox Studio workflows with direct Studio control, sync, playtest, UI Studio, and dashboard monitoring",
-    "version": "2.7.6"
+    "description": "WEPPY Roblox AI Toolkit — WEPPY AI Agent Plugin and MCP setup for live Roblox Studio workflows with direct Studio control, sync, playtest, UI Studio, and dashboard monitoring",
+    "version": "2.7.7"
   },
   "plugins": [
     {
-      "name": "weppy-roblox-mcp",
+      "name": "weppy-roblox-ai-toolkit",
       "source": "./plugins/weppy-roblox-mcp",
-      "description": "WEPPY Roblox MCP — WEPPY AI Agent Plugin and MCP setup for live Roblox Studio workflows.",
-      "version": "2.7.6",
+      "description": "WEPPY Roblox AI Toolkit — WEPPY AI Agent Plugin and MCP setup for live Roblox Studio workflows.",
+      "version": "2.7.7",
       "author": {
         "name": "hope1026"
       },

--- a/.github/workflows/install-test.yml
+++ b/.github/workflows/install-test.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           node-version: '24'
 
-      - name: Verify — public repo WEPPY AI Agent Plugin layout
+      - name: Verify — public repo WEPPY Roblox AI Toolkit layout
         run: |
           node <<'NODE'
           const fs = require('fs');
@@ -83,9 +83,28 @@ jobs:
 
           const claudePlugin = JSON.parse(fs.readFileSync(path.join(root, 'plugins/weppy-roblox-mcp/.claude-plugin/plugin.json'), 'utf8'));
           const codexPlugin = JSON.parse(fs.readFileSync(path.join(root, 'plugins/weppy-roblox-mcp/.codex-plugin/plugin.json'), 'utf8'));
+          const codexMarketplace = JSON.parse(fs.readFileSync(path.join(root, '.agents/plugins/marketplace.json'), 'utf8'));
           const codexMcp = JSON.parse(fs.readFileSync(path.join(root, 'plugins/weppy-roblox-mcp/.mcp.json'), 'utf8'));
           const expected = { command: 'npx', args: ['-y', '@weppy/roblox-mcp@latest'] };
 
+          if (codexMarketplace.interface?.displayName !== 'WEPPY Roblox AI Toolkit') {
+            throw new Error('Codex marketplace display name must be WEPPY Roblox AI Toolkit');
+          }
+          if (codexMarketplace.plugins?.[0]?.name !== 'weppy-roblox-ai-toolkit') {
+            throw new Error('Codex marketplace plugin id must be weppy-roblox-ai-toolkit');
+          }
+          if (JSON.stringify(codexMarketplace.plugins?.[0]?.source) !== JSON.stringify({ source: 'local', path: './plugins/weppy-roblox-mcp' })) {
+            throw new Error('Codex marketplace source must point to local plugin path');
+          }
+          if (claudePlugin.name !== 'weppy-roblox-ai-toolkit') {
+            throw new Error('Claude plugin id must be weppy-roblox-ai-toolkit');
+          }
+          if (codexPlugin.name !== 'weppy-roblox-ai-toolkit') {
+            throw new Error('Codex plugin id must be weppy-roblox-ai-toolkit');
+          }
+          if (codexPlugin.interface?.displayName !== 'WEPPY Roblox AI Toolkit') {
+            throw new Error('Codex plugin display name must be WEPPY Roblox AI Toolkit');
+          }
           if (JSON.stringify(claudePlugin.mcpServers?.['weppy-roblox-mcp']) !== JSON.stringify(expected)) {
             throw new Error('Claude plugin MCP command is not @latest npm command');
           }
@@ -145,7 +164,7 @@ jobs:
             throw new Error('mcp-actions.md must be generated from tool-codegen');
           }
 
-          console.log('✓ Public repo WEPPY AI Agent Plugin layout verified');
+          console.log('✓ Public repo WEPPY Roblox AI Toolkit layout verified');
           NODE
 
       - name: Verify — npm package runtime tarball shape
@@ -303,7 +322,7 @@ jobs:
             ls -la "$HOME/.claude" || true
             exit 1
           fi
-          if ! grep -q 'weppy-roblox-mcp@hope1026-roblox-mcp' "$HOME/.claude/weppy-plugin-installed"; then
+          if ! grep -q 'weppy-roblox-ai-toolkit@hope1026-roblox-mcp' "$HOME/.claude/weppy-plugin-installed"; then
             echo "❌ Claude Code plugin install was not called"
             ls -la "$HOME/.claude" || true
             exit 1
@@ -491,7 +510,7 @@ jobs:
             Get-ChildItem $claudeDir -Force
             exit 1
           }
-          if (-not ((Get-Content $pluginMarker -Raw) -match 'weppy-roblox-mcp@hope1026-roblox-mcp')) {
+          if (-not ((Get-Content $pluginMarker -Raw) -match 'weppy-roblox-ai-toolkit@hope1026-roblox-mcp')) {
             Write-Error "❌ Claude Code plugin install was not called"
             Get-ChildItem $claudeDir -Force
             exit 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ All notable changes to this project will be documented in this file.
 
 
 
+
+## [2.7.7] - 2026-05-14
+
+### Bug Fixes
+
+- **Codex Plugin Directory installation** — The Codex marketplace entry now uses the installable plugin metadata expected by Codex and appears as **WEPPY Roblox AI Toolkit**. The MCP server id and npm command stay unchanged, while Codex users can install the plugin and load the included WEPPY skills from Plugin Directory.
+
+### Documentation
+
+- **Clearer Claude Code and Codex setup names** — Install guides now use the same plugin id and display name across the public README, one-line installer guidance, and website docs, reducing confusion between the MCP server and the agent plugin.
+
 ## [2.7.6] - 2026-05-14
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ irm https://raw.githubusercontent.com/hope1026/weppy-roblox-mcp/main/install.ps1
 Then reopen your AI app and restart Roblox Studio.
 
 Automatic MCP registration supports Claude Code, Claude Desktop, Cursor, Codex CLI/App, Gemini CLI, and Antigravity.
-For Claude Code, the installer also tries to add and install the WEPPY AI Agent Plugin. For Codex, it adds the WEPPY AI Agent Plugin marketplace and then asks you to install WEPPY Roblox MCP from Plugin Directory.
+For Claude Code, the installer also tries to add and install the WEPPY Roblox AI Toolkit. For Codex, it adds the WEPPY Roblox AI Toolkit marketplace and then asks you to install WEPPY Roblox AI Toolkit from Plugin Directory.
 
 ### Manual Install
 
@@ -61,15 +61,15 @@ Supported AI apps are Claude Code, Claude Desktop, Cursor, Codex CLI, Codex App,
 
 > Any MCP-compatible AI client works. The server command is `npx -y @weppy/roblox-mcp@latest`.
 
-### Optional WEPPY AI Agent Plugin
+### Optional WEPPY Roblox AI Toolkit
 
-Claude Code and Codex can also use the WEPPY AI Agent Plugin. The MCP server command above is enough to use WEPPY; the plugin adds client-native setup and workflow guidance.
+Claude Code and Codex can also use the WEPPY Roblox AI Toolkit. The MCP server command above is enough to use WEPPY; the plugin adds client-native setup and workflow guidance.
 
 **Claude Code**
 
 ```bash
 claude plugin marketplace add hope1026/weppy-roblox-mcp --scope user
-claude plugin install weppy-roblox-mcp@hope1026-roblox-mcp --scope user
+claude plugin install weppy-roblox-ai-toolkit@hope1026-roblox-mcp --scope user
 ```
 
 **Codex**
@@ -78,7 +78,7 @@ claude plugin install weppy-roblox-mcp@hope1026-roblox-mcp --scope user
 codex plugin marketplace add hope1026/weppy-roblox-mcp
 ```
 
-After adding the Codex marketplace, restart Codex, open Plugin Directory, and install **WEPPY Roblox MCP**.
+After adding the Codex marketplace, restart Codex, open Plugin Directory, and install **WEPPY Roblox AI Toolkit**.
 
 ## Compatibility
 
@@ -180,10 +180,10 @@ For app setup details, open the web docs hub and choose the relevant AI client g
 ## FAQ
 
 ### How do I connect Claude Code to Roblox Studio?
-Install from the web install page or add the WEPPY AI Agent Plugin for Claude Code with the commands above. The WEPPY AI Agent Plugin uses `npx -y @weppy/roblox-mcp@latest` as the MCP server command.
+Install from the web install page or add the WEPPY Roblox AI Toolkit for Claude Code with the commands above. The WEPPY Roblox AI Toolkit uses `npx -y @weppy/roblox-mcp@latest` as the MCP server command.
 
 ### How do I use Codex CLI with Roblox Studio?
-Install the Roblox Studio plugin, then add the MCP server config to Codex CLI. You can also add the Codex plugin marketplace and install WEPPY Roblox MCP from Plugin Directory.
+Install the Roblox Studio plugin, then add the MCP server config to Codex CLI. You can also add the Codex plugin marketplace and install WEPPY Roblox AI Toolkit from Plugin Directory.
 
 ### Does Roblox MCP work with Cursor?
 Yes. Any MCP-compatible AI client works.

--- a/install.ps1
+++ b/install.ps1
@@ -7,7 +7,7 @@
 # Interactive 3 steps:
 #   [1/3] Setup — install Roblox Studio Plugin via npx
 #   [2/3] Register MCP with AI apps (user selection)
-#   [3/3] Setup WEPPY AI Agent Plugin for Claude Code / Codex (best effort)
+#   [3/3] Setup WEPPY Roblox AI Toolkit for Claude Code / Codex (best effort)
 #
 
 $ErrorActionPreference = "Stop"
@@ -976,12 +976,12 @@ else {
 }
 
 # ═══════════════════════════════════
-# [3/3] Setup WEPPY AI Agent Plugin
+# [3/3] Setup WEPPY Roblox AI Toolkit
 # ═══════════════════════════════════
-Write-Step "3/3" "Setup WEPPY AI Agent Plugin"
+Write-Step "3/3" "Setup WEPPY Roblox AI Toolkit"
 
 if ($env:WEPPY_SKIP_AI_AGENT_PLUGIN -eq '1') {
-    Write-Warn "WEPPY AI Agent Plugin setup skipped (WEPPY_SKIP_AI_AGENT_PLUGIN=1)"
+    Write-Warn "WEPPY Roblox AI Toolkit setup skipped (WEPPY_SKIP_AI_AGENT_PLUGIN=1)"
 }
 else {
     $aiAgentPluginAny = $false
@@ -995,13 +995,13 @@ else {
             Write-Ok "Claude Code marketplace ready"
 
             $claudePluginStderr = Join-Path ([System.IO.Path]::GetTempPath()) ("weppy-claude-plugin-install-{0}.err" -f ([System.Guid]::NewGuid().ToString("N")))
-            $claudePluginExit = Invoke-AiAgentPluginCommand $claudeCodeCliCommand @('plugin', 'install', 'weppy-roblox-mcp@hope1026-roblox-mcp', '--scope', 'user') $claudePluginStderr
+            $claudePluginExit = Invoke-AiAgentPluginCommand $claudeCodeCliCommand @('plugin', 'install', 'weppy-roblox-ai-toolkit@hope1026-roblox-mcp', '--scope', 'user') $claudePluginStderr
 
             if ($claudePluginExit -eq 0 -or (Test-AiAgentPluginAlreadyReady $claudePluginStderr)) {
-                Write-Ok "WEPPY AI Agent Plugin for Claude Code ready"
+                Write-Ok "WEPPY Roblox AI Toolkit for Claude Code ready"
             }
             else {
-                Write-Warn "WEPPY AI Agent Plugin install for Claude Code skipped or failed (non-blocking)"
+                Write-Warn "WEPPY Roblox AI Toolkit install for Claude Code skipped or failed (non-blocking)"
                 Write-AiAgentPluginStderr $claudePluginStderr
             }
             Remove-Item $claudePluginStderr -ErrorAction SilentlyContinue
@@ -1013,7 +1013,7 @@ else {
         Remove-Item $claudeMarketplaceStderr -ErrorAction SilentlyContinue
     }
     else {
-        Write-Warn "WEPPY AI Agent Plugin for Claude Code skipped (claude CLI not found)"
+        Write-Warn "WEPPY Roblox AI Toolkit for Claude Code skipped (claude CLI not found)"
     }
 
     if ($codexCliCommand) {
@@ -1023,7 +1023,7 @@ else {
 
         if ($codexMarketplaceExit -eq 0 -or (Test-AiAgentPluginAlreadyReady $codexMarketplaceStderr)) {
             Write-Ok "Codex marketplace ready"
-            Write-Host "    Restart Codex, open Plugin Directory, then install WEPPY Roblox MCP."
+            Write-Host "    Restart Codex, open Plugin Directory, then install WEPPY Roblox AI Toolkit."
         }
         else {
             Write-Warn "Codex marketplace setup skipped or failed (non-blocking)"
@@ -1032,11 +1032,11 @@ else {
         Remove-Item $codexMarketplaceStderr -ErrorAction SilentlyContinue
     }
     else {
-        Write-Warn "WEPPY AI Agent Plugin for Codex skipped (codex CLI not found)"
+        Write-Warn "WEPPY Roblox AI Toolkit for Codex skipped (codex CLI not found)"
     }
 
     if (-not $aiAgentPluginAny) {
-        Write-Info "WEPPY AI Agent Plugin can be installed later from Claude Code or Codex plugin marketplace"
+        Write-Info "WEPPY Roblox AI Toolkit can be installed later from Claude Code or Codex plugin marketplace"
     }
 }
 
@@ -1054,7 +1054,7 @@ Write-Host "  3. Click Connect and start building with AI!"
 Write-Host ""
 Write-Host "  Auto registration: Claude Code, Claude Desktop, Cursor, Codex CLI/App, Gemini CLI, Antigravity"
 Write-Host ""
-Write-Host "  WEPPY AI Agent Plugin: Claude Code installs automatically when supported; Codex opens from Plugin Directory after marketplace add."
+Write-Host "  WEPPY Roblox AI Toolkit: Claude Code installs automatically when supported; Codex opens from Plugin Directory after marketplace add."
 Write-Host ""
 Write-Host "  Docs: https://weppyai.com/en/install" -ForegroundColor DarkGray
 Write-Host ""

--- a/install.sh
+++ b/install.sh
@@ -8,7 +8,7 @@
 # Interactive 3 steps:
 #   [1/3] Setup — install Roblox Studio Plugin via npx
 #   [2/3] Register MCP with AI apps (user selection)
-#   [3/3] Setup WEPPY AI Agent Plugin for Claude Code / Codex (best effort)
+#   [3/3] Setup WEPPY Roblox AI Toolkit for Claude Code / Codex (best effort)
 #
 
 set -euo pipefail
@@ -929,12 +929,12 @@ else
 fi
 
 # ═══════════════════════════════════
-# [3/3] Setup WEPPY AI Agent Plugin
+# [3/3] Setup WEPPY Roblox AI Toolkit
 # ═══════════════════════════════════
-step "3/3" "Setup WEPPY AI Agent Plugin"
+step "3/3" "Setup WEPPY Roblox AI Toolkit"
 
 if [ "${WEPPY_SKIP_AI_AGENT_PLUGIN:-}" = "1" ]; then
-  warn "WEPPY AI Agent Plugin setup skipped (WEPPY_SKIP_AI_AGENT_PLUGIN=1)"
+  warn "WEPPY Roblox AI Toolkit setup skipped (WEPPY_SKIP_AI_AGENT_PLUGIN=1)"
 else
   ai_agent_plugin_any=false
 
@@ -948,11 +948,11 @@ else
 
       claude_plugin_stderr=$(mktemp "${TMPDIR:-/tmp}/weppy-claude-plugin-install-XXXXXX.err" 2>/dev/null || echo "${HOME}/weppy-claude-plugin-install.err")
       claude_plugin_exit=0
-      "$CLAUDE_CLI_COMMAND" plugin install weppy-roblox-mcp@hope1026-roblox-mcp --scope user 2>"$claude_plugin_stderr" || claude_plugin_exit=$?
+      "$CLAUDE_CLI_COMMAND" plugin install weppy-roblox-ai-toolkit@hope1026-roblox-mcp --scope user 2>"$claude_plugin_stderr" || claude_plugin_exit=$?
       if [ "$claude_plugin_exit" -eq 0 ] || is_already_ai_agent_plugin_result "$claude_plugin_stderr"; then
-        success "WEPPY AI Agent Plugin for Claude Code ready"
+        success "WEPPY Roblox AI Toolkit for Claude Code ready"
       else
-        warn "WEPPY AI Agent Plugin install for Claude Code skipped or failed (non-blocking)"
+        warn "WEPPY Roblox AI Toolkit install for Claude Code skipped or failed (non-blocking)"
         sed 's/^/    /' "$claude_plugin_stderr" || true
       fi
       rm -f "$claude_plugin_stderr"
@@ -962,7 +962,7 @@ else
     fi
     rm -f "$claude_marketplace_stderr"
   else
-    warn "WEPPY AI Agent Plugin for Claude Code skipped (claude CLI not found)"
+    warn "WEPPY Roblox AI Toolkit for Claude Code skipped (claude CLI not found)"
   fi
 
   if [ -n "${CODEX_CLI_COMMAND:-}" ]; then
@@ -972,18 +972,18 @@ else
     "$CODEX_CLI_COMMAND" plugin marketplace add hope1026/weppy-roblox-mcp 2>"$codex_marketplace_stderr" || codex_marketplace_exit=$?
     if [ "$codex_marketplace_exit" -eq 0 ] || is_already_ai_agent_plugin_result "$codex_marketplace_stderr"; then
       success "Codex marketplace ready"
-      printf "    Restart Codex, open Plugin Directory, then install WEPPY Roblox MCP.\n"
+      printf "    Restart Codex, open Plugin Directory, then install WEPPY Roblox AI Toolkit.\n"
     else
       warn "Codex marketplace setup skipped or failed (non-blocking)"
       sed 's/^/    /' "$codex_marketplace_stderr" || true
     fi
     rm -f "$codex_marketplace_stderr"
   else
-    warn "WEPPY AI Agent Plugin for Codex skipped (codex CLI not found)"
+    warn "WEPPY Roblox AI Toolkit for Codex skipped (codex CLI not found)"
   fi
 
   if [ "$ai_agent_plugin_any" = false ]; then
-    info "WEPPY AI Agent Plugin can be installed later from Claude Code or Codex plugin marketplace"
+    info "WEPPY Roblox AI Toolkit can be installed later from Claude Code or Codex plugin marketplace"
   fi
 fi
 
@@ -1001,6 +1001,6 @@ printf "  1. Restart Roblox Studio\n"
 printf "  2. Look for the ${BOLD}WEPPY${NC} button in the Plugins tab\n"
 printf "  3. Click Connect and start building with AI!\n\n"
 printf "  Auto registration: Claude Code, Claude Desktop, Cursor, Codex CLI/App, Gemini CLI, Antigravity\n\n"
-printf "  WEPPY AI Agent Plugin: Claude Code installs automatically when supported; Codex opens from Plugin Directory after marketplace add.\n\n"
+printf "  WEPPY Roblox AI Toolkit: Claude Code installs automatically when supported; Codex opens from Plugin Directory after marketplace add.\n\n"
 # shellcheck disable=SC2059
 printf "  ${DIM}Docs: https://weppyai.com/en/install${NC}\n\n"

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -12,13 +12,13 @@ Canonical documentation lives on the web:
 
 For app-specific setup, open the web install page and choose the relevant AI client guide.
 
-Optional WEPPY AI Agent Plugin:
+Optional WEPPY Roblox AI Toolkit:
 
 - Claude Code:
 
 ```bash
 claude plugin marketplace add hope1026/weppy-roblox-mcp --scope user
-claude plugin install weppy-roblox-mcp@hope1026-roblox-mcp --scope user
+claude plugin install weppy-roblox-ai-toolkit@hope1026-roblox-mcp --scope user
 ```
 
 - Codex:
@@ -27,4 +27,4 @@ claude plugin install weppy-roblox-mcp@hope1026-roblox-mcp --scope user
 codex plugin marketplace add hope1026/weppy-roblox-mcp
 ```
 
-After adding the Codex marketplace, restart Codex, open Plugin Directory, and install WEPPY Roblox MCP.
+After adding the Codex marketplace, restart Codex, open Plugin Directory, and install WEPPY Roblox AI Toolkit.

--- a/llms.txt
+++ b/llms.txt
@@ -38,15 +38,15 @@ irm https://raw.githubusercontent.com/hope1026/weppy-roblox-mcp/main/install.ps1
 
 Safari / Firefox users should open the web install page and follow the browser-specific guide there.
 
-## Optional WEPPY AI Agent Plugin
+## Optional WEPPY Roblox AI Toolkit
 
-Claude Code and Codex can also use the WEPPY AI Agent Plugin.
+Claude Code and Codex can also use the WEPPY Roblox AI Toolkit.
 
 Claude Code:
 
 ```bash
 claude plugin marketplace add hope1026/weppy-roblox-mcp --scope user
-claude plugin install weppy-roblox-mcp@hope1026-roblox-mcp --scope user
+claude plugin install weppy-roblox-ai-toolkit@hope1026-roblox-mcp --scope user
 ```
 
 Codex:
@@ -55,7 +55,7 @@ Codex:
 codex plugin marketplace add hope1026/weppy-roblox-mcp
 ```
 
-After adding the Codex marketplace, restart Codex, open Plugin Directory, and install WEPPY Roblox MCP.
+After adding the Codex marketplace, restart Codex, open Plugin Directory, and install WEPPY Roblox AI Toolkit.
 
 ## Tiers
 

--- a/plugins/weppy-roblox-mcp/.claude-plugin/plugin.json
+++ b/plugins/weppy-roblox-mcp/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
-  "name": "weppy-roblox-mcp",
-  "description": "WEPPY Roblox MCP setup for Claude Code.",
-  "version": "2.7.6",
+  "name": "weppy-roblox-ai-toolkit",
+  "description": "WEPPY Roblox AI Toolkit setup for Claude Code.",
+  "version": "2.7.7",
   "author": {
     "name": "hope1026"
   },

--- a/plugins/weppy-roblox-mcp/.codex-plugin/plugin.json
+++ b/plugins/weppy-roblox-mcp/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
-  "name": "weppy-roblox-mcp",
-  "version": "2.7.6",
-  "description": "WEPPY Roblox MCP setup for Codex.",
+  "name": "weppy-roblox-ai-toolkit",
+  "version": "2.7.7",
+  "description": "WEPPY Roblox AI Toolkit setup for Codex.",
   "author": {
     "name": "hope1026"
   },
@@ -17,5 +17,24 @@
     "codex"
   ],
   "skills": "./skills/",
-  "mcpServers": "./.mcp.json"
+  "mcpServers": "./.mcp.json",
+  "interface": {
+    "displayName": "WEPPY Roblox AI Toolkit",
+    "shortDescription": "Roblox Studio MCP, skills, and workflows",
+    "longDescription": "Use WEPPY with Roblox Studio from Codex, including MCP tools, UI Studio guidance, playtest workflows, sync guidance, and Roblox Explorer context.",
+    "developerName": "hope1026",
+    "category": "Coding",
+    "capabilities": [
+      "Interactive",
+      "Write"
+    ],
+    "websiteURL": "https://www.weppyai.com/",
+    "privacyPolicyURL": "https://github.com/hope1026/weppy-roblox-mcp#readme",
+    "termsOfServiceURL": "https://github.com/hope1026/weppy-roblox-mcp/blob/main/LICENSE",
+    "defaultPrompt": [
+      "Control Roblox Studio with WEPPY and use the included workflow skills"
+    ],
+    "brandColor": "#14B8A6",
+    "screenshots": []
+  }
 }


### PR DESCRIPTION
## Release v2.7.7


### Bug Fixes

- **Codex Plugin Directory installation** — The Codex marketplace entry now uses the installable plugin metadata expected by Codex and appears as **WEPPY Roblox AI Toolkit**. The MCP server id and npm command stay unchanged, while Codex users can install the plugin and load the included WEPPY skills from Plugin Directory.

### Documentation

- **Clearer Claude Code and Codex setup names** — Install guides now use the same plugin id and display name across the public README, one-line installer guidance, and website docs, reducing confusion between the MCP server and the agent plugin.

---
Automated release from weppy-roblox-mcp-private