### PR TITLE
Release v2.7.13

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "WEPPY Roblox AI Toolkit — AI Agent Plugin and MCP setup for live Roblox Studio workflows with direct Studio control, sync, playtest, UI Studio, and dashboard monitoring",
-    "version": "2.7.12"
+    "version": "2.7.13"
   },
   "plugins": [
     {
@@ -20,7 +20,7 @@
       },
       "category": "Coding",
       "description": "WEPPY Roblox AI Toolkit setup for Codex.",
-      "version": "2.7.12"
+      "version": "2.7.13"
     }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "WEPPY Roblox AI Toolkit — WEPPY AI Agent Plugin and MCP setup for live Roblox Studio workflows with direct Studio control, sync, playtest, UI Studio, and dashboard monitoring",
-    "version": "2.7.12"
+    "version": "2.7.13"
   },
   "plugins": [
     {
       "name": "weppy-roblox-ai-toolkit",
       "source": "./plugins/weppy-roblox-mcp",
       "description": "WEPPY Roblox AI Toolkit — WEPPY AI Agent Plugin and MCP setup for live Roblox Studio workflows.",
-      "version": "2.7.12",
+      "version": "2.7.13",
       "author": {
         "name": "hope1026"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this project will be documented in this file.
 
 
+
+## [2.7.13] - 2026-06-02
+
+### Stability
+
+- **Stability improvements** — WEPPY now tracks first-time MCP usage more reliably for operations reporting while keeping existing Studio workflows unchanged. No setup changes are required.
+
 ## [2.7.12] - 2026-05-28
 
 ### Features

--- a/plugins/weppy-roblox-mcp/.claude-plugin/plugin.json
+++ b/plugins/weppy-roblox-mcp/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "weppy-roblox-ai-toolkit",
   "description": "WEPPY Roblox AI Toolkit setup for Claude Code.",
-  "version": "2.7.12",
+  "version": "2.7.13",
   "author": {
     "name": "hope1026"
   },

--- a/plugins/weppy-roblox-mcp/.codex-plugin/plugin.json
+++ b/plugins/weppy-roblox-mcp/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "weppy-roblox-ai-toolkit",
-  "version": "2.7.12",
+  "version": "2.7.13",
   "description": "WEPPY Roblox AI Toolkit setup for Codex.",
   "author": {
     "name": "hope1026"

--- a/plugins/weppy-roblox-mcp/skills/weppy-roblox-mcp-guide/references/mcp-actions.md
+++ b/plugins/weppy-roblox-mcp/skills/weppy-roblox-mcp-guide/references/mcp-actions.md
@@ -1746,6 +1746,107 @@ export current selection.
   - `includeChildren` - boolean - Include children in export. Used by: export. Default: false.
   - `maxDepth` - number - Maximum depth for recursive child export. Used by: export. Default: 5.
 
+## Tool: `manage_open_cloud_assets`
+
+[PRO] Roblox Open Cloud asset upload: credential status, category capabilities, upload local files, update assets, read metadata, and poll operation status. Does not expose delete/archive/restore actions.
+
+### `manage_open_cloud_assets.credential_status`
+
+check local Open Cloud credential status without exposing the raw API key.
+
+- Tier: `pro`
+- Route: `internal`
+- Execution mode: `readonly`
+- Param aliases: none
+- Required params: none
+- Optional params: none
+
+### `manage_open_cloud_assets.capabilities`
+
+list supported upload categories, extensions, and update capabilities.
+
+- Tier: `pro`
+- Route: `internal`
+- Execution mode: `readonly`
+- Param aliases: none
+- Required params: none
+- Optional params: none
+
+### `manage_open_cloud_assets.upload`
+
+upload a local file as a new Roblox asset through Open Cloud.
+
+- Tier: `pro`
+- Route: `internal`
+- Execution mode: `mutating`
+- Param aliases: none
+- Required params:
+  - `filePath` - string - Local file path on the MCP server machine. Used by: upload, update.
+  - `category` - "image" | "decal" | "audio" | "mesh" | "model" | "video" | "animation" - WEPPY asset category. Used by: upload, update.
+  - `displayName` - string - Roblox asset display name. Used by: upload, update.
+- Optional params:
+  - `contextId` - string - Optional execution context identifier. Used to continue an existing context for mutating actions.
+  - `contextSummary` - ExecutionContextSummary - Optional structured execution context attached to this tool call.
+  - `replayMetadata` - ExecutionReplayMetadata - Optional replay-ready metadata attached to this tool call.
+  - `description` - string - Roblox asset description. Used by: upload, update.
+  - `creatorType` - "user" | "group" - Asset creator owner type. Used by: upload, update. Defaults to saved credential metadata when available.
+  - `creatorId` - string - User ID or group ID for the asset creator. Used by: upload, update. Defaults to saved credential metadata when available.
+  - `expectedPrice` - number - Expected upload fee in Robux. Used by: upload, update when Roblox requires an expected price.
+  - `waitForOperation` - boolean - When true, poll the returned Open Cloud operation until done or timeout. Used by: upload, update.
+  - `operationPollTimeoutMs` - number - Maximum operation polling time in milliseconds. Used by: upload, update when waitForOperation is true.
+  - `operationPollIntervalMs` - number - Operation polling interval in milliseconds. Used by: upload, update when waitForOperation is true.
+
+### `manage_open_cloud_assets.update`
+
+update an existing Roblox asset through Open Cloud.
+
+- Tier: `pro`
+- Route: `internal`
+- Execution mode: `mutating`
+- Param aliases: none
+- Required params:
+  - `assetId` - string - Roblox asset ID. Used by: update (required), info (required).
+  - `category` - "image" | "decal" | "audio" | "mesh" | "model" | "video" | "animation" - WEPPY asset category. Used by: upload, update.
+- Optional params:
+  - `contextId` - string - Optional execution context identifier. Used to continue an existing context for mutating actions.
+  - `contextSummary` - ExecutionContextSummary - Optional structured execution context attached to this tool call.
+  - `replayMetadata` - ExecutionReplayMetadata - Optional replay-ready metadata attached to this tool call.
+  - `filePath` - string - Local file path on the MCP server machine. Used by: upload, update.
+  - `displayName` - string - Roblox asset display name. Used by: upload, update.
+  - `description` - string - Roblox asset description. Used by: upload, update.
+  - `creatorType` - "user" | "group" - Asset creator owner type. Used by: upload, update. Defaults to saved credential metadata when available.
+  - `creatorId` - string - User ID or group ID for the asset creator. Used by: upload, update. Defaults to saved credential metadata when available.
+  - `expectedPrice` - number - Expected upload fee in Robux. Used by: upload, update when Roblox requires an expected price.
+  - `updateMask` - array<string> - Metadata fields to update. Used by: update.
+  - `waitForOperation` - boolean - When true, poll the returned Open Cloud operation until done or timeout. Used by: upload, update.
+  - `operationPollTimeoutMs` - number - Maximum operation polling time in milliseconds. Used by: upload, update when waitForOperation is true.
+  - `operationPollIntervalMs` - number - Operation polling interval in milliseconds. Used by: upload, update when waitForOperation is true.
+
+### `manage_open_cloud_assets.info`
+
+read Roblox asset metadata through Open Cloud.
+
+- Tier: `pro`
+- Route: `internal`
+- Execution mode: `readonly`
+- Param aliases: none
+- Required params:
+  - `assetId` - string - Roblox asset ID. Used by: update (required), info (required).
+- Optional params:
+  - `readMask` - array<string> - Asset metadata fields to retrieve. Used by: info.
+
+### `manage_open_cloud_assets.operation_status`
+
+read Open Cloud operation status for upload/update processing.
+
+- Tier: `pro`
+- Route: `internal`
+- Execution mode: `readonly`
+- Param aliases: none
+- Required params:
+  - `operationId` - string - Roblox Open Cloud operation ID or operations/{id} path. Used by: operation_status.
+- Optional params: none
+
 ## Tool: `manage_sync`
 
 [PRO] Project sync management: status, history, direction settings, read/write synced files.


### PR DESCRIPTION
## Release v2.7.13


### Stability

- **Stability improvements** — WEPPY now tracks first-time MCP usage more reliably for operations reporting while keeping existing Studio workflows unchanged. No setup changes are required.

---
Automated release from weppy-roblox-mcp-private