### PR TITLE
Release v2.7.17

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "WEPPY Roblox AI Toolkit — AI Agent Plugin and MCP setup for live Roblox Studio workflows with direct Studio control, sync, playtest, UI Studio, and dashboard monitoring",
-    "version": "2.7.16"
+    "version": "2.7.17"
   },
   "plugins": [
     {
@@ -20,7 +20,7 @@
       },
       "category": "Coding",
       "description": "WEPPY Roblox AI Toolkit setup for Codex.",
-      "version": "2.7.16"
+      "version": "2.7.17"
     }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "WEPPY Roblox AI Toolkit — WEPPY AI Agent Plugin and MCP setup for live Roblox Studio workflows with direct Studio control, sync, playtest, UI Studio, and dashboard monitoring",
-    "version": "2.7.16"
+    "version": "2.7.17"
   },
   "plugins": [
     {
       "name": "weppy-roblox-ai-toolkit",
       "source": "./plugins/weppy-roblox-mcp",
       "description": "WEPPY Roblox AI Toolkit — WEPPY AI Agent Plugin and MCP setup for live Roblox Studio workflows.",
-      "version": "2.7.16",
+      "version": "2.7.17",
       "author": {
         "name": "hope1026"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 
 
 
+
+## [2.7.17] - 2026-06-07
+
+### Bug Fixes
+
+- **More reliable Codex Play testing controls** — Fixes an intermittent issue where starting or stopping Play tests from Codex could miss the active Roblox Studio play session, leaving `play` or `stop` commands stuck until retried.
+
 ## [2.7.16] - 2026-06-05
 
 ### Bug Fixes

--- a/plugins/weppy-roblox-mcp/.claude-plugin/plugin.json
+++ b/plugins/weppy-roblox-mcp/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "weppy-roblox-ai-toolkit",
   "description": "WEPPY Roblox AI Toolkit setup for Claude Code.",
-  "version": "2.7.16",
+  "version": "2.7.17",
   "author": {
     "name": "hope1026"
   },

--- a/plugins/weppy-roblox-mcp/.codex-plugin/plugin.json
+++ b/plugins/weppy-roblox-mcp/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "weppy-roblox-ai-toolkit",
-  "version": "2.7.16",
+  "version": "2.7.17",
   "description": "WEPPY Roblox AI Toolkit setup for Codex.",
   "author": {
     "name": "hope1026"


### PR DESCRIPTION
## Release v2.7.17


### Bug Fixes

- **More reliable Codex Play testing controls** — Fixes an intermittent issue where starting or stopping Play tests from Codex could miss the active Roblox Studio play session, leaving `play` or `stop` commands stuck until retried.

---
Automated release from weppy-roblox-mcp-private