### PR TITLE
Release v2.7.18

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "WEPPY Roblox AI Toolkit — AI Agent Plugin and MCP setup for live Roblox Studio workflows with direct Studio control, sync, playtest, UI Studio, and dashboard monitoring",
-    "version": "2.7.17"
+    "version": "2.7.18"
   },
   "plugins": [
     {
@@ -20,7 +20,7 @@
       },
       "category": "Coding",
       "description": "WEPPY Roblox AI Toolkit setup for Codex.",
-      "version": "2.7.17"
+      "version": "2.7.18"
     }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "WEPPY Roblox AI Toolkit — WEPPY AI Agent Plugin and MCP setup for live Roblox Studio workflows with direct Studio control, sync, playtest, UI Studio, and dashboard monitoring",
-    "version": "2.7.17"
+    "version": "2.7.18"
   },
   "plugins": [
     {
       "name": "weppy-roblox-ai-toolkit",
       "source": "./plugins/weppy-roblox-mcp",
       "description": "WEPPY Roblox AI Toolkit — WEPPY AI Agent Plugin and MCP setup for live Roblox Studio workflows.",
-      "version": "2.7.17",
+      "version": "2.7.18",
       "author": {
         "name": "hope1026"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ All notable changes to this project will be documented in this file.
 
 
 
+
+## [2.7.18] - 2026-06-08
+
+### Stability
+
+- **Clearer sync disk-error troubleshooting** — When Project Sync cannot start because the local sync folder cannot be written, WEPPY now keeps the underlying disk or permission message in the Studio error details and server logs instead of only showing `Disk error`. This makes support logs more actionable without changing the sync workflow.
+
 ## [2.7.17] - 2026-06-07
 
 ### Bug Fixes

--- a/plugins/weppy-roblox-mcp/.claude-plugin/plugin.json
+++ b/plugins/weppy-roblox-mcp/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "weppy-roblox-ai-toolkit",
   "description": "WEPPY Roblox AI Toolkit setup for Claude Code.",
-  "version": "2.7.17",
+  "version": "2.7.18",
   "author": {
     "name": "hope1026"
   },

--- a/plugins/weppy-roblox-mcp/.codex-plugin/plugin.json
+++ b/plugins/weppy-roblox-mcp/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "weppy-roblox-ai-toolkit",
-  "version": "2.7.17",
+  "version": "2.7.18",
   "description": "WEPPY Roblox AI Toolkit setup for Codex.",
   "author": {
     "name": "hope1026"


### PR DESCRIPTION
## Release v2.7.18


### Stability

- **Clearer sync disk-error troubleshooting** — When Project Sync cannot start because the local sync folder cannot be written, WEPPY now keeps the underlying disk or permission message in the Studio error details and server logs instead of only showing `Disk error`. This makes support logs more actionable without changing the sync workflow.

---
Automated release from weppy-roblox-mcp-private