### PR TITLE
Release v2.8.2

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "WEPPY Roblox AI Toolkit — AI Agent Plugin and MCP setup for live Roblox Studio workflows with direct Studio control, sync, playtest, UI Studio, and dashboard monitoring",
-    "version": "2.8.1"
+    "version": "2.8.2"
   },
   "plugins": [
     {
@@ -20,7 +20,7 @@
       },
       "category": "Coding",
       "description": "WEPPY Roblox AI Toolkit setup for Codex.",
-      "version": "2.8.1"
+      "version": "2.8.2"
     }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "WEPPY Roblox AI Toolkit — WEPPY AI Agent Plugin and MCP setup for live Roblox Studio workflows with direct Studio control, sync, playtest, UI Studio, and dashboard monitoring",
-    "version": "2.8.1"
+    "version": "2.8.2"
   },
   "plugins": [
     {
       "name": "weppy-roblox-ai-toolkit",
       "source": "./plugins/weppy-roblox-mcp",
       "description": "WEPPY Roblox AI Toolkit — WEPPY AI Agent Plugin and MCP setup for live Roblox Studio workflows.",
-      "version": "2.8.1",
+      "version": "2.8.2",
       "author": {
         "name": "hope1026"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ All notable changes to this project will be documented in this file.
 
 
 
+
+## [2.8.2] - 2026-06-15
+
+### Bug Fixes
+
+- **More complete Dashboard bug reports** — Bug reports opened from WEPPY Dashboard now keep the Roblox Studio version when Studio reconnects or refreshes its plugin metadata. If the Plugin cannot report the Studio version, WEPPY also checks the installed Roblox Studio app or executable and marks that value as an installed-app fallback in the GitHub issue prefill. This gives support reports the Studio version more consistently without requiring any setup change.
+
 ## [2.8.1] - 2026-06-15
 
 ### Features

--- a/plugins/weppy-roblox-mcp/.claude-plugin/plugin.json
+++ b/plugins/weppy-roblox-mcp/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "weppy-roblox-ai-toolkit",
   "description": "WEPPY Roblox AI Toolkit setup for Claude Code.",
-  "version": "2.8.1",
+  "version": "2.8.2",
   "author": {
     "name": "hope1026"
   },

--- a/plugins/weppy-roblox-mcp/.codex-plugin/plugin.json
+++ b/plugins/weppy-roblox-mcp/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "weppy-roblox-ai-toolkit",
-  "version": "2.8.1",
+  "version": "2.8.2",
   "description": "WEPPY Roblox AI Toolkit setup for Codex.",
   "author": {
     "name": "hope1026"


### PR DESCRIPTION
## Release v2.8.2


### Bug Fixes

- **More complete Dashboard bug reports** — Bug reports opened from WEPPY Dashboard now keep the Roblox Studio version when Studio reconnects or refreshes its plugin metadata. If the Plugin cannot report the Studio version, WEPPY also checks the installed Roblox Studio app or executable and marks that value as an installed-app fallback in the GitHub issue prefill. This gives support reports the Studio version more consistently without requiring any setup change.

---
Automated release from weppy-roblox-mcp-private