### PR TITLE
Release v2.9.1

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "WEPPY Roblox AI Toolkit — AI Agent Plugin and MCP setup for live Roblox Studio workflows with direct Studio control, sync, playtest, UI Studio, and dashboard monitoring",
-    "version": "2.9.0"
+    "version": "2.9.1"
   },
   "plugins": [
     {
@@ -20,7 +20,7 @@
       },
       "category": "Coding",
       "description": "WEPPY Roblox AI Toolkit setup for Codex.",
-      "version": "2.9.0"
+      "version": "2.9.1"
     }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "WEPPY Roblox AI Toolkit — WEPPY AI Agent Plugin and MCP setup for live Roblox Studio workflows with direct Studio control, sync, playtest, UI Studio, and dashboard monitoring",
-    "version": "2.9.0"
+    "version": "2.9.1"
   },
   "plugins": [
     {
       "name": "weppy-roblox-ai-toolkit",
       "source": "./plugins/weppy-roblox-mcp",
       "description": "WEPPY Roblox AI Toolkit — WEPPY AI Agent Plugin and MCP setup for live Roblox Studio workflows.",
-      "version": "2.9.0",
+      "version": "2.9.1",
       "author": {
         "name": "hope1026"
       },

--- a/.github/ISSUE_TEMPLATE/install_help.yml
+++ b/.github/ISSUE_TEMPLATE/install_help.yml
@@ -8,17 +8,11 @@ body:
         **First:** check the [Installation Guide](https://github.com/hope1026/weppy-roblox-mcp/blob/main/docs/en/installation/README.md)
         and [Troubleshooting](https://github.com/hope1026/weppy-roblox-mcp/blob/main/docs/en/troubleshooting.md).
         For general questions, use [Discussions](https://github.com/hope1026/weppy-roblox-mcp/discussions) instead.
-  - type: dropdown
+  - type: input
     id: ai-client
     attributes:
       label: AI client
-      options:
-        - Claude Code
-        - Claude Desktop
-        - Cursor
-        - Codex CLI
-        - Gemini CLI
-        - Other
+      placeholder: "Claude Code 1.x / Cursor 0.4x / Codex App / Gemini CLI"
     validations:
       required: true
   - type: input
@@ -35,6 +29,11 @@ body:
       placeholder: "node --version output"
     validations:
       required: true
+  - type: input
+    id: plugin-version
+    attributes:
+      label: MCP / Plugin / Studio version
+      placeholder: "MCP 2.x / Plugin 2.x / Studio 0.x, or leave blank if not installed yet"
   - type: textarea
     id: issue
     attributes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ All notable changes to this project will be documented in this file.
 
 
 
+
+## [2.9.1] - 2026-06-21
+
+### Stability
+
+- **Cleaner Pro upgrade links from the Studio plugin** — The Pro guide now shows a shorter plans link that is easier to copy from Roblox Studio, while WEPPY still records the visit as plugin traffic on the website. This improves purchase-path reporting without changing the upgrade flow or requiring any setup change.
+
 ## [2.9.0] - 2026-06-18
 
 ### Features

--- a/plugins/weppy-roblox-mcp/.claude-plugin/plugin.json
+++ b/plugins/weppy-roblox-mcp/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "weppy-roblox-ai-toolkit",
   "description": "WEPPY Roblox AI Toolkit setup for Claude Code.",
-  "version": "2.9.0",
+  "version": "2.9.1",
   "author": {
     "name": "hope1026"
   },

--- a/plugins/weppy-roblox-mcp/.codex-plugin/plugin.json
+++ b/plugins/weppy-roblox-mcp/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "weppy-roblox-ai-toolkit",
-  "version": "2.9.0",
+  "version": "2.9.1",
   "description": "WEPPY Roblox AI Toolkit setup for Codex.",
   "author": {
     "name": "hope1026"


### PR DESCRIPTION
## Release v2.9.1


### Stability

- **Cleaner Pro upgrade links from the Studio plugin** — The Pro guide now shows a shorter plans link that is easier to copy from Roblox Studio, while WEPPY still records the visit as plugin traffic on the website. This improves purchase-path reporting without changing the upgrade flow or requiring any setup change.

---
Automated release from weppy-roblox-mcp-private