### PR TITLE
Release v2.9.3

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "WEPPY Roblox AI Toolkit — AI Agent Plugin and MCP setup for live Roblox Studio workflows with direct Studio control, sync, playtest, UI Studio, and dashboard monitoring",
-    "version": "2.9.2"
+    "version": "2.9.3"
   },
   "plugins": [
     {
@@ -20,7 +20,7 @@
       },
       "category": "Coding",
       "description": "WEPPY Roblox AI Toolkit setup for Codex.",
-      "version": "2.9.2"
+      "version": "2.9.3"
     }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "WEPPY Roblox AI Toolkit — WEPPY AI Agent Plugin and MCP setup for live Roblox Studio workflows with direct Studio control, sync, playtest, UI Studio, and dashboard monitoring",
-    "version": "2.9.2"
+    "version": "2.9.3"
   },
   "plugins": [
     {
       "name": "weppy-roblox-ai-toolkit",
       "source": "./plugins/weppy-roblox-mcp",
       "description": "WEPPY Roblox AI Toolkit — WEPPY AI Agent Plugin and MCP setup for live Roblox Studio workflows.",
-      "version": "2.9.2",
+      "version": "2.9.3",
       "author": {
         "name": "hope1026"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,18 @@ All notable changes to this project will be documented in this file.
 
 
 
+
+## [2.9.3] - 2026-06-27
+
+### Bug Fixes
+
+- **Recover from invalid licenses without leaving Roblox Studio** — When an existing Pro license becomes invalid, revoked, or needs manual reactivation, the Dashboard and Studio plugin now keep the recovery controls available. You can enter a new license key or reset the old local registration instead of getting stuck with disabled license buttons.
+
+### Stability
+
+- **More reliable Project Sync restart cleanup** — If a full sync fails or is restarted while Studio reconnects, WEPPY now recognizes cleanup requests from the same plugin process even when the temporary client ID changed. This reduces cases where a stale sync session blocks the next sync attempt.
+- **Clearer sync conflict details in Studio logs** — Sync ownership conflicts now preserve the server's detailed message in the Studio plugin logs, making it easier to see which connection or sync session is blocking the action.
+
 ## [2.9.2] - 2026-06-23
 
 ### Stability

--- a/plugins/weppy-roblox-mcp/.claude-plugin/plugin.json
+++ b/plugins/weppy-roblox-mcp/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "weppy-roblox-ai-toolkit",
   "description": "WEPPY Roblox AI Toolkit setup for Claude Code.",
-  "version": "2.9.2",
+  "version": "2.9.3",
   "author": {
     "name": "hope1026"
   },

--- a/plugins/weppy-roblox-mcp/.codex-plugin/plugin.json
+++ b/plugins/weppy-roblox-mcp/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "weppy-roblox-ai-toolkit",
-  "version": "2.9.2",
+  "version": "2.9.3",
   "description": "WEPPY Roblox AI Toolkit setup for Codex.",
   "author": {
     "name": "hope1026"


### PR DESCRIPTION
## Release v2.9.3


### Bug Fixes

- **Recover from invalid licenses without leaving Roblox Studio** — When an existing Pro license becomes invalid, revoked, or needs manual reactivation, the Dashboard and Studio plugin now keep the recovery controls available. You can enter a new license key or reset the old local registration instead of getting stuck with disabled license buttons.

### Stability

- **More reliable Project Sync restart cleanup** — If a full sync fails or is restarted while Studio reconnects, WEPPY now recognizes cleanup requests from the same plugin process even when the temporary client ID changed. This reduces cases where a stale sync session blocks the next sync attempt.
- **Clearer sync conflict details in Studio logs** — Sync ownership conflicts now preserve the server's detailed message in the Studio plugin logs, making it easier to see which connection or sync session is blocking the action.

---
Automated release from weppy-roblox-mcp-private