### PR TITLE
Release v2.11.0

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "WEPPY AI Agent Plugin marketplace for Codex — MCP setup and workflow guidance for the WEPPY Roblox AI Toolkit",
-    "version": "2.10.4"
+    "version": "2.11.0"
   },
   "plugins": [
     {
@@ -20,7 +20,7 @@
       },
       "category": "Coding",
       "description": "WEPPY AI Agent Plugin for Codex.",
-      "version": "2.10.4"
+      "version": "2.11.0"
     }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "WEPPY AI Agent Plugin marketplace for Claude Code — MCP setup and workflow guidance for the WEPPY Roblox AI Toolkit",
-    "version": "2.10.4"
+    "version": "2.11.0"
   },
   "plugins": [
     {
       "name": "weppy-roblox-ai-toolkit",
       "source": "./plugins/weppy-roblox-mcp",
       "description": "WEPPY AI Agent Plugin for Claude Code — MCP setup and workflow guidance for the WEPPY Roblox AI Toolkit.",
-      "version": "2.10.4",
+      "version": "2.11.0",
       "author": {
         "name": "hope1026"
       },

--- a/.github/validation/skill-coverage.json
+++ b/.github/validation/skill-coverage.json
@@ -46,6 +46,7 @@
       "skill": "weppy-roblox-assets-guide",
       "reference": "references/open-cloud-upload.md",
       "actions": [
+        "manage_open_cloud_assets.preflight",
         "manage_open_cloud_assets.credential_status",
         "manage_open_cloud_assets.capabilities",
         "manage_open_cloud_assets.upload",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,23 @@ All notable changes to this project will be documented in this file.
 
 
 
+
+## [2.11.0] - 2026-07-19
+
+### Features
+
+- **Cleaner Project Sync files with a reviewed v3 update** — New Sync projects now use a canonical file format that avoids unnecessary Git diffs when the same Studio state is synced again. Existing v2 projects stay unchanged until you review the exact metadata additions, modifications, deletions, and blockers in the Dashboard Sync page and explicitly apply the update. WEPPY creates a runtime backup before applying it and does not modify Luau source files. After a place is updated to v3, opening that Sync data with an older MCP server is not supported; projects that remain on v2 continue to work normally.
+- **Read-only Studio readiness checks before AI work** — AI agents can now use `system_info.preflight` to check the selected Studio connection, place identity, Edit or Play state, publish status, screenshot readiness, and security capabilities before starting a task. The check reports specific setup actions without changing Studio settings, the DataModel, or DataStore state.
+- **Read-only Open Cloud upload checks** — Pro users can now verify the saved API key, Assets Read and Write permissions, Creator target, requested asset category, and local file format and size before uploading. Running `manage_open_cloud_assets.preflight` does not upload or update a Roblox asset and does not expose the raw API key.
+
+### Bug Fixes
+
+- **No duplicate events in completed Playtest reports** — `manage_studio.run_test` no longer records the same logs and signals twice when a completed test reports them through both the final result and the live event stream. Timeout and cancellation reports still preserve the available partial stream evidence, including intentional repeated messages.
+
+### Stability
+
+- **Less Sync metadata noise in Git and Dashboard history** — Runtime files such as session and timestamp state are ignored by WEPPY-managed Git rules and excluded from game-change history, while generated files can be distinguished from user source and canonical mirror changes. Existing user `.gitignore` rules and already tracked files are left in place.
+
 ## [2.10.4] - 2026-07-18
 
 ### Features

--- a/plugins/weppy-roblox-mcp/.claude-plugin/plugin.json
+++ b/plugins/weppy-roblox-mcp/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "weppy-roblox-ai-toolkit",
   "description": "WEPPY AI Agent Plugin for Claude Code.",
-  "version": "2.10.4",
+  "version": "2.11.0",
   "author": {
     "name": "hope1026"
   },

--- a/plugins/weppy-roblox-mcp/.codex-plugin/plugin.json
+++ b/plugins/weppy-roblox-mcp/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "weppy-roblox-ai-toolkit",
-  "version": "2.10.4",
+  "version": "2.11.0",
   "description": "WEPPY AI Agent Plugin for Codex.",
   "author": {
     "name": "hope1026"

--- a/plugins/weppy-roblox-mcp/skills/weppy-roblox-assets-guide/references/open-cloud-upload.md
+++ b/plugins/weppy-roblox-mcp/skills/weppy-roblox-assets-guide/references/open-cloud-upload.md
@@ -1,10 +1,11 @@
 # Open Cloud Upload Reference
 
-1. Call `manage_open_cloud_assets.credential_status` without exposing the raw API key.
-2. Call `manage_open_cloud_assets.capabilities` and confirm the file extension and category pair.
-3. Confirm Creator type and ID, ownership intent, and expected upload fee when required.
-4. Use `manage_open_cloud_assets.upload` for a new remote asset or `manage_open_cloud_assets.update` only when the user explicitly asks to change an existing asset ID.
-5. Use `manage_open_cloud_assets.operation_status` until processing completes when the first response is pending.
-6. Verify the returned asset ID, operation ID, status, Creator, and local source path.
+1. Call `manage_open_cloud_assets.preflight` to check the upload toggle, credential authentication, Assets Read/Write, Creator target, and optional file readiness without uploading.
+2. Call `manage_open_cloud_assets.credential_status` only when credential profile metadata is also needed, without exposing the raw API key.
+3. Call `manage_open_cloud_assets.capabilities` and confirm the file extension and category pair.
+4. Confirm Creator type and ID, ownership intent, and expected upload fee when required.
+5. Use `manage_open_cloud_assets.upload` for a new remote asset or `manage_open_cloud_assets.update` only when the user explicitly asks to change an existing asset ID.
+6. Use `manage_open_cloud_assets.operation_status` until processing completes when the first response is pending.
+7. Verify the returned asset ID, operation ID, status, Creator, and local source path.
 
 WEPPY does not expose remote Roblox asset deletion, archive, or restore actions. Never pass a raw API key in tool parameters, logs, or skill output.

--- a/plugins/weppy-roblox-mcp/skills/weppy-roblox-mcp-guide/references/mcp-actions.md
+++ b/plugins/weppy-roblox-mcp/skills/weppy-roblox-mcp-guide/references/mcp-actions.md
@@ -1248,7 +1248,7 @@ get suggested camera view for a target.
 
 ### `manage_camera.screenshot`
 
-**EDIT MODE ONLY — DO NOT call during an active playtest.** Captures the current Studio Edit-mode viewport as a PNG image (MCP image content). Pre-check: call manage_studio.play_status and only proceed when state == "edit". The handler will fail with a clear error if a playtest is running. Requires the Studio setting "Allow Mesh / Image APIs" (Game Settings > Security). v1 does not support Play-mode capture because Roblox blocks converting CaptureService temporary contentId into EditableImage outside the edit DM plugin context (confirmed by Roblox engineers on devforum).
+**EDIT MODE ONLY — DO NOT call during an active playtest.** Captures the current Studio Edit-mode viewport as a PNG image (MCP image content). Pre-check: call manage_studio.play_status and only proceed when state == "edit". The handler will fail with a clear error if a playtest is running. Requires Studio Mesh/Image capability. In Studio, open File → Experience Settings → Security and enable "Allow Mesh / Image APIs". v1 does not support Play-mode capture because Roblox blocks converting CaptureService temporary contentId into EditableImage outside the edit DM plugin context (confirmed by Roblox engineers on devforum).
 
 - Tier: `pro`
 - Route: `plugin`
@@ -2374,7 +2374,22 @@ generate or replace thumbnail.png for an Asset Library .rbxm asset.
 
 ## Tool: `manage_open_cloud_assets`
 
-[PRO] Roblox Open Cloud asset upload: credential status, category capabilities, upload local files, update assets, read metadata, and poll operation status. Does not expose delete/archive/restore actions.
+[PRO] Roblox Open Cloud asset upload: preflight diagnostics, credential status, category capabilities, upload local files, update assets, read metadata, and poll operation status. Does not expose delete/archive/restore actions.
+
+### `manage_open_cloud_assets.preflight`
+
+diagnose credential, Assets Read/Write permissions, Creator target, category, and local file readiness without uploading. Credential guidance: In Roblox Creator Hub, create an API key, add Assets under Access Permissions, enable both Read and Write, then save and test the key in WEPPY Assets settings. File guidance: Check that the selected asset category, file extension, and file size satisfy the Roblox Assets API requirements.
+
+- Tier: `pro`
+- Route: `internal`
+- Execution mode: `readonly`
+- Param aliases: none
+- Required params: none
+- Optional params:
+  - `filePath` - string - Local file path on the MCP server machine. Used by: upload, update.
+  - `category` - "image" | "decal" | "audio" | "mesh" | "model" | "video" | "animation" - WEPPY asset category. Used by: upload, update.
+  - `creatorType` - "user" | "group" - Asset creator owner type. Used by: upload, update. Defaults to saved credential metadata when available.
+  - `creatorId` - string - User ID or group ID for the asset creator. Used by: upload, update. Defaults to saved credential metadata when available.
 
 ### `manage_open_cloud_assets.credential_status`
 
@@ -2740,7 +2755,7 @@ quick access to recent errors only.
 
 ## Tool: `system_info`
 
-System info: ping, connection status, usage tier. [PRO] place info, services list, studio settings.
+System info: ping, connection status, usage tier, and read-only Studio preflight diagnostics. [PRO] place info and services list.
 
 ### `system_info.ping`
 
@@ -2800,11 +2815,13 @@ System info: ping, connection status, usage tier. [PRO] place info, services lis
   - `clientId` - string - Optional Studio target selector. Routes this call to the exact connected WEPPY Plugin client. Takes precedence over targetAlias and placeId.
   - `targetAlias` - string - Optional Studio target selector. Routes this call to the connected WEPPY Studio target alias shown in Dashboard/Plugin, such as studio-1. Takes precedence over placeId.
 
-### `system_info.studio_settings`
+### `system_info.preflight`
 
-- Tier: `pro`
-- Route: `plugin`
-- Execution mode: `unspecified`
+diagnose Studio connection, identity, state, publish status, and security capabilities without changing Studio or DataStore state. API Services guidance: In Studio, open File → Experience Settings → Security and enable "Enable Studio Access to API Services". Mesh/Image guidance: In Studio, open File → Experience Settings → Security and enable "Allow Mesh / Image APIs".
+
+- Tier: `basic`
+- Route: `internal`
+- Execution mode: `readonly`
 - Param aliases: none
 - Required params: none
 - Optional params:


### PR DESCRIPTION
## Release v2.11.0


### Features

- **Cleaner Project Sync files with a reviewed v3 update** — New Sync projects now use a canonical file format that avoids unnecessary Git diffs when the same Studio state is synced again. Existing v2 projects stay unchanged until you review the exact metadata additions, modifications, deletions, and blockers in the Dashboard Sync page and explicitly apply the update. WEPPY creates a runtime backup before applying it and does not modify Luau source files. After a place is updated to v3, opening that Sync data with an older MCP server is not supported; projects that remain on v2 continue to work normally.
- **Read-only Studio readiness checks before AI work** — AI agents can now use `system_info.preflight` to check the selected Studio connection, place identity, Edit or Play state, publish status, screenshot readiness, and security capabilities before starting a task. The check reports specific setup actions without changing Studio settings, the DataModel, or DataStore state.
- **Read-only Open Cloud upload checks** — Pro users can now verify the saved API key, Assets Read and Write permissions, Creator target, requested asset category, and local file format and size before uploading. Running `manage_open_cloud_assets.preflight` does not upload or update a Roblox asset and does not expose the raw API key.

### Bug Fixes

- **No duplicate events in completed Playtest reports** — `manage_studio.run_test` no longer records the same logs and signals twice when a completed test reports them through both the final result and the live event stream. Timeout and cancellation reports still preserve the available partial stream evidence, including intentional repeated messages.

### Stability

- **Less Sync metadata noise in Git and Dashboard history** — Runtime files such as session and timestamp state are ignored by WEPPY-managed Git rules and excluded from game-change history, while generated files can be distinguished from user source and canonical mirror changes. Existing user `.gitignore` rules and already tracked files are left in place.

---
Automated release from weppy-roblox-mcp-private