### PR TITLE
Release v2.11.1

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "WEPPY AI Agent Plugin marketplace for Codex — MCP setup and workflow guidance for the WEPPY Roblox AI Toolkit",
-    "version": "2.11.0"
+    "version": "2.11.1"
   },
   "plugins": [
     {
@@ -20,7 +20,7 @@
       },
       "category": "Coding",
       "description": "WEPPY AI Agent Plugin for Codex.",
-      "version": "2.11.0"
+      "version": "2.11.1"
     }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "WEPPY AI Agent Plugin marketplace for Claude Code — MCP setup and workflow guidance for the WEPPY Roblox AI Toolkit",
-    "version": "2.11.0"
+    "version": "2.11.1"
   },
   "plugins": [
     {
       "name": "weppy-roblox-ai-toolkit",
       "source": "./plugins/weppy-roblox-mcp",
       "description": "WEPPY AI Agent Plugin for Claude Code — MCP setup and workflow guidance for the WEPPY Roblox AI Toolkit.",
-      "version": "2.11.0",
+      "version": "2.11.1",
       "author": {
         "name": "hope1026"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,18 @@ All notable changes to this project will be documented in this file.
 
 
 
+
+## [2.11.1] - 2026-07-24
+
+### Features
+
+- **Read only the script lines you need** — AI agents can now request a specific line range from large scripts instead of loading the entire source every time. Range reads are available on Basic, preserve the original source text, and report the actual returned range when a request extends past the end of the script.
+- **See when a tool request includes unused options** — WEPPY now returns a non-blocking warning when an AI agent sends options that the selected operation does not use. The operation still runs, while the warning helps the agent correct the next request instead of silently assuming those options took effect.
+
+### Documentation
+
+- **Refreshed Dashboard What's New** — The Dashboard now highlights recent preflight, script-reading, request-warning, and Playtest report improvements in all supported languages. May announcements have been removed from the bundled feed.
+
 ## [2.11.0] - 2026-07-19
 
 ### Features

--- a/plugins/weppy-roblox-mcp/.claude-plugin/plugin.json
+++ b/plugins/weppy-roblox-mcp/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "weppy-roblox-ai-toolkit",
   "description": "WEPPY AI Agent Plugin for Claude Code.",
-  "version": "2.11.0",
+  "version": "2.11.1",
   "author": {
     "name": "hope1026"
   },

--- a/plugins/weppy-roblox-mcp/.codex-plugin/plugin.json
+++ b/plugins/weppy-roblox-mcp/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "weppy-roblox-ai-toolkit",
-  "version": "2.11.0",
+  "version": "2.11.1",
   "description": "WEPPY AI Agent Plugin for Codex.",
   "author": {
     "name": "hope1026"

--- a/plugins/weppy-roblox-mcp/skills/weppy-roblox-mcp-guide/references/mcp-actions.md
+++ b/plugins/weppy-roblox-mcp/skills/weppy-roblox-mcp-guide/references/mcp-actions.md
@@ -723,6 +723,8 @@ Manage script source code: read, write, create, delete, edit lines, search. [PRO
 - Required params:
   - `path` - string - Path to the script instance. Used by: get_source, set_source, delete, edit_replace, edit_insert, edit_delete, search, get_dependencies, replace.
 - Optional params:
+  - `startLine` - number - Starting line number, 1-based inclusive. Used by: get_source (paired with endLine), edit_replace, edit_delete. get_source requires an integer.
+  - `endLine` - number - Ending line number, 1-based inclusive. Used by: get_source (paired with startLine), edit_replace, edit_delete. get_source requires an integer.
   - `placeId` - number - Optional Studio target selector. When multiple Studio clients are connected, route this call to the active client for this Roblox placeId. If no matching active client exists, the call fails instead of falling back to another Place.
   - `clientId` - string - Optional Studio target selector. Routes this call to the exact connected WEPPY Plugin client. Takes precedence over targetAlias and placeId.
   - `targetAlias` - string - Optional Studio target selector. Routes this call to the connected WEPPY Studio target alias shown in Dashboard/Plugin, such as studio-1. Takes precedence over placeId.
@@ -779,8 +781,8 @@ Manage script source code: read, write, create, delete, edit lines, search. [PRO
   - `newLines` -> `newContent`
 - Required params:
   - `path` - string - Path to the script instance. Used by: get_source, set_source, delete, edit_replace, edit_insert, edit_delete, search, get_dependencies, replace.
-  - `startLine` - number - Starting line number, 1-based inclusive. Used by: edit_replace, edit_delete.
-  - `endLine` - number - Ending line number, 1-based inclusive. Used by: edit_replace, edit_delete.
+  - `startLine` - number - Starting line number, 1-based inclusive. Used by: get_source (paired with endLine), edit_replace, edit_delete. get_source requires an integer.
+  - `endLine` - number - Ending line number, 1-based inclusive. Used by: get_source (paired with startLine), edit_replace, edit_delete. get_source requires an integer.
   - `newLines` - string - New content to replace specified lines. Used by: edit_replace. Can be multi-line.
 - Optional params:
   - `placeId` - number - Optional Studio target selector. When multiple Studio clients are connected, route this call to the active client for this Roblox placeId. If no matching active client exists, the call fails instead of falling back to another Place.
@@ -812,8 +814,8 @@ Manage script source code: read, write, create, delete, edit lines, search. [PRO
 - Param aliases: none
 - Required params:
   - `path` - string - Path to the script instance. Used by: get_source, set_source, delete, edit_replace, edit_insert, edit_delete, search, get_dependencies, replace.
-  - `startLine` - number - Starting line number, 1-based inclusive. Used by: edit_replace, edit_delete.
-  - `endLine` - number - Ending line number, 1-based inclusive. Used by: edit_replace, edit_delete.
+  - `startLine` - number - Starting line number, 1-based inclusive. Used by: get_source (paired with endLine), edit_replace, edit_delete. get_source requires an integer.
+  - `endLine` - number - Ending line number, 1-based inclusive. Used by: get_source (paired with startLine), edit_replace, edit_delete. get_source requires an integer.
 - Optional params:
   - `placeId` - number - Optional Studio target selector. When multiple Studio clients are connected, route this call to the active client for this Roblox placeId. If no matching active client exists, the call fails instead of falling back to another Place.
   - `clientId` - string - Optional Studio target selector. Routes this call to the exact connected WEPPY Plugin client. Takes precedence over targetAlias and placeId.


### PR DESCRIPTION
## Release v2.11.1


### Features

- **Read only the script lines you need** — AI agents can now request a specific line range from large scripts instead of loading the entire source every time. Range reads are available on Basic, preserve the original source text, and report the actual returned range when a request extends past the end of the script.
- **See when a tool request includes unused options** — WEPPY now returns a non-blocking warning when an AI agent sends options that the selected operation does not use. The operation still runs, while the warning helps the agent correct the next request instead of silently assuming those options took effect.

### Documentation

- **Refreshed Dashboard What's New** — The Dashboard now highlights recent preflight, script-reading, request-warning, and Playtest report improvements in all supported languages. May announcements have been removed from the bundled feed.

---
Automated release from weppy-roblox-mcp-private