### PR TITLE
Release v2.12.4

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "WEPPY AI Agent Plugin marketplace for Codex — MCP setup and workflow guidance for the WEPPY Roblox AI Toolkit",
-    "version": "2.12.3"
+    "version": "2.12.4"
   },
   "plugins": [
     {
@@ -20,7 +20,7 @@
       },
       "category": "Coding",
       "description": "WEPPY AI Agent Plugin for Codex.",
-      "version": "2.12.3"
+      "version": "2.12.4"
     }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "WEPPY AI Agent Plugin marketplace for Claude Code — MCP setup and workflow guidance for the WEPPY Roblox AI Toolkit",
-    "version": "2.12.3"
+    "version": "2.12.4"
   },
   "plugins": [
     {
       "name": "weppy-roblox-ai-toolkit",
       "source": "./plugins/weppy-roblox-mcp",
       "description": "WEPPY AI Agent Plugin for Claude Code — MCP setup and workflow guidance for the WEPPY Roblox AI Toolkit.",
-      "version": "2.12.3",
+      "version": "2.12.4",
       "author": {
         "name": "hope1026"
       },

--- a/.github/validation/skill-coverage.json
+++ b/.github/validation/skill-coverage.json
@@ -50,6 +50,7 @@
         "manage_open_cloud_assets.credential_status",
         "manage_open_cloud_assets.capabilities",
         "manage_open_cloud_assets.upload",
+        "manage_open_cloud_assets.link",
         "manage_open_cloud_assets.update",
         "manage_open_cloud_assets.info",
         "manage_open_cloud_assets.operation_status"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,24 @@ All notable changes to this project will be documented in this file.
 
 
 
+
+## [2.12.4] - 2026-08-13
+
+### Features
+
+- **Keep Open Cloud uploads in the Asset Library** — Uploading an image, audio file, model, or video through Open Cloud now creates or reuses the matching shared or Place asset record automatically. Existing non-Decal Roblox assets can also be linked to a local file without uploading them again, and repeated requests return the same library item.
+
+### Bug Fixes
+
+- **Resume Project Sync after its WebSocket reconnects** — If the local MCP server restarts or the command connection drops while Sync is active, the Studio plugin now reconnects, cleans up the previous session, and starts a fresh full sync with the same one-time or continuous intent, direction settings, and preserved-file choices.
+- **Keep one stable folder for each Place during Sync** — Concurrent starts and Place ID promotion now use the same canonical folder. Duplicate folders are archived only after a successful full sync, so interrupted or failed syncs keep recoverable local data.
+- **Keep Project Change Summary writes reliable on Windows** — Concurrent history writes and cleanup now share one file-access queue, preventing transient Windows rename locks from losing a session or stopping later cleanup work.
+- **Reject unsafe Open Cloud library writes before local state changes** — Disabled uploads stop before creating a local library item, links require a verified matching Roblox asset type, and concurrent duplicate links converge on one item instead of producing duplicates.
+
+### Stability
+
+- **Safer local MCP restarts during Studio development** — The local stop script now targets only processes listening on the MCP ports, so an attached Roblox Studio client is not mistaken for the server.
+
 ## [2.12.3] - 2026-08-12
 
 ### Bug Fixes

--- a/plugins/weppy-roblox-mcp/.claude-plugin/plugin.json
+++ b/plugins/weppy-roblox-mcp/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "weppy-roblox-ai-toolkit",
   "description": "WEPPY AI Agent Plugin for Claude Code.",
-  "version": "2.12.3",
+  "version": "2.12.4",
   "author": {
     "name": "hope1026"
   },

--- a/plugins/weppy-roblox-mcp/.codex-plugin/plugin.json
+++ b/plugins/weppy-roblox-mcp/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "weppy-roblox-ai-toolkit",
-  "version": "2.12.3",
+  "version": "2.12.4",
   "description": "WEPPY AI Agent Plugin for Codex.",
   "author": {
     "name": "hope1026"

--- a/plugins/weppy-roblox-mcp/skills/weppy-roblox-assets-guide/SKILL.md
+++ b/plugins/weppy-roblox-mcp/skills/weppy-roblox-assets-guide/SKILL.md
@@ -12,7 +12,7 @@ description: Use when creating, importing, reviewing, uploading, updating, or re
 3. Read `references/creator-store.md` before searching, inspecting, or inserting a Creator Store asset.
 4. Read `references/generated-assets.md` when an AI image file or Roblox GenerationService model is involved.
 5. Read `references/studio-upload.md` before any Studio-local upload or temporary embedded-resource upload.
-6. Read `references/open-cloud-upload.md` before credential checks, Open Cloud upload or update, and operation polling.
+6. Read `references/open-cloud-upload.md` before credential checks, Open Cloud upload, existing asset linking, update, and operation polling.
 7. Ask for explicit approval whenever the workflow can create billable or temporary Roblox assets.
 8. Verify the returned local asset ID, Roblox asset ID or URI, operation status, and intended Creator before using the result.
 

--- a/plugins/weppy-roblox-mcp/skills/weppy-roblox-assets-guide/references/asset-library.md
+++ b/plugins/weppy-roblox-mcp/skills/weppy-roblox-assets-guide/references/asset-library.md
@@ -9,4 +9,8 @@ Use Asset Library for local, inspectable asset round-trips.
 5. Use `manage_assets.import_rbxm` to place the reviewed item back into Studio.
 6. Verify `assetLibraryAssetId`, scope, Place ID, source path, and imported Studio path.
 
+`manage_open_cloud_assets.upload` automatically copies its local source into the selected Asset Library scope and records the Roblox upload lifecycle on that item. Use `manage_open_cloud_assets.link` to register an existing non-Decal Roblox asset ID with a local source without creating a duplicate remote asset. Decal wrapper IDs cannot be linked because the Asset Library requires the backing Image asset ID.
+
+The Dashboard lists these local Asset Library items. It does not query the complete Roblox inventory for a user or group.
+
 Local Asset Library deletion removes only the Asset Library-owned local item. It never means remote Roblox asset deletion.

--- a/plugins/weppy-roblox-mcp/skills/weppy-roblox-assets-guide/references/generated-assets.md
+++ b/plugins/weppy-roblox-mcp/skills/weppy-roblox-assets-guide/references/generated-assets.md
@@ -1,6 +1,6 @@
 # Generated Assets Reference
 
-For AI-generated image files, save a supported local image first, then choose Studio-local or Open Cloud upload according to the requested owner and workflow.
+For AI-generated image files, save a supported local image first, then choose Studio-local or Open Cloud upload according to the requested owner and workflow. `manage_open_cloud_assets.upload` registers its stable local copy in the selected Asset Library scope. Use `manage_open_cloud_assets.link` instead when the image already has a Roblox asset ID.
 
 For Roblox model generation:
 

--- a/plugins/weppy-roblox-mcp/skills/weppy-roblox-assets-guide/references/open-cloud-upload.md
+++ b/plugins/weppy-roblox-mcp/skills/weppy-roblox-assets-guide/references/open-cloud-upload.md
@@ -1,11 +1,14 @@
 # Open Cloud Upload Reference
 
-1. Call `manage_open_cloud_assets.preflight` to check the upload toggle, credential authentication, Assets Read/Write, Creator target, and optional file readiness without uploading.
-2. Call `manage_open_cloud_assets.credential_status` only when credential profile metadata is also needed, without exposing the raw API key.
-3. Call `manage_open_cloud_assets.capabilities` and confirm the file extension and category pair.
-4. Confirm Creator type and ID, ownership intent, and expected upload fee when required.
-5. Use `manage_open_cloud_assets.upload` for a new remote asset or `manage_open_cloud_assets.update` only when the user explicitly asks to change an existing asset ID.
-6. Use `manage_open_cloud_assets.operation_status` until processing completes when the first response is pending.
-7. Verify the returned asset ID, operation ID, status, Creator, and local source path.
+1. Choose `scope="place"` for the current game or `scope="shared"` for project-wide reuse. Place scope uses the current runtime Place ID unless `placeId` is provided and fails before upload when no Place is available.
+2. Call `manage_open_cloud_assets.preflight` to check the upload toggle, credential authentication, Assets Read/Write, Creator target, and optional file readiness without uploading.
+3. Call `manage_open_cloud_assets.credential_status` only when credential profile metadata is also needed, without exposing the raw API key.
+4. Call `manage_open_cloud_assets.capabilities` and confirm the file extension and category pair.
+5. Confirm Creator type and ID, ownership intent, and expected upload fee when required.
+6. Use `manage_open_cloud_assets.upload` for a new remote asset. It copies the source into the selected Asset Library scope, tracks upload or processing state, and returns the stable Asset Library ID with Roblox metadata.
+7. Use `manage_open_cloud_assets.link` when a non-Decal Roblox asset already exists. It verifies the remote asset and connects the existing ID to the local source without another upload. The link action rejects Decal wrapper IDs because the Asset Library requires the backing Image asset ID. Do not call `upload` to backfill an existing ID.
+8. Use `manage_open_cloud_assets.update` only when the user explicitly asks to change an existing asset ID.
+9. Use `manage_open_cloud_assets.operation_status` when a standalone operation must be checked. The Dashboard also resumes bounded status refresh for Asset Library items that remain in processing.
+10. Verify `assetLibraryAssetId`, Roblox asset ID and URI, operation status, Creator, scope, and the preserved local source.
 
-WEPPY does not expose remote Roblox asset deletion, archive, or restore actions. Never pass a raw API key in tool parameters, logs, or skill output.
+The Dashboard lists local Asset Library items, not every asset owned by the Roblox user or group. WEPPY does not expose remote Roblox asset deletion, archive, or restore actions. Never pass a raw API key in tool parameters, logs, or skill output.

--- a/plugins/weppy-roblox-mcp/skills/weppy-roblox-mcp-guide/references/mcp-actions.md
+++ b/plugins/weppy-roblox-mcp/skills/weppy-roblox-mcp-guide/references/mcp-actions.md
@@ -2396,7 +2396,7 @@ generate or replace thumbnail.png for an Asset Library .rbxm asset.
 
 ## Tool: `manage_open_cloud_assets`
 
-[PRO] Roblox Open Cloud asset upload: preflight diagnostics, credential status, category capabilities, upload local files, update assets, read metadata, and poll operation status. Does not expose delete/archive/restore actions.
+[PRO] Roblox Open Cloud asset upload: preflight diagnostics, credential status, category capabilities, Asset Library-backed upload, existing asset linking, updates, metadata reads, and operation polling. Does not expose delete/archive/restore actions.
 
 ### `manage_open_cloud_assets.preflight`
 
@@ -2408,8 +2408,8 @@ diagnose credential, Assets Read/Write permissions, Creator target, category, an
 - Param aliases: none
 - Required params: none
 - Optional params:
-  - `filePath` - string - Local file path on the MCP server machine. Used by: upload, update.
-  - `category` - "image" | "decal" | "audio" | "mesh" | "model" | "video" | "animation" - WEPPY asset category. Used by: upload, update.
+  - `filePath` - string - Local file path on the MCP server machine. Used by: upload, link, update.
+  - `category` - "image" | "decal" | "audio" | "mesh" | "model" | "video" | "animation" - WEPPY asset category. Used by: upload, link, update. The link action does not support decal because it requires the backing Image asset ID.
   - `creatorType` - "user" | "group" - Asset creator owner type. Used by: upload, update. Defaults to saved credential metadata when available.
   - `creatorId` - string - User ID or group ID for the asset creator. Used by: upload, update. Defaults to saved credential metadata when available.
 
@@ -2444,20 +2444,43 @@ upload a local file as a new Roblox asset through Open Cloud.
 - Execution mode: `mutating`
 - Param aliases: none
 - Required params:
-  - `filePath` - string - Local file path on the MCP server machine. Used by: upload, update.
-  - `category` - "image" | "decal" | "audio" | "mesh" | "model" | "video" | "animation" - WEPPY asset category. Used by: upload, update.
-  - `displayName` - string - Roblox asset display name. Used by: upload, update.
+  - `filePath` - string - Local file path on the MCP server machine. Used by: upload, link, update.
+  - `category` - "image" | "decal" | "audio" | "mesh" | "model" | "video" | "animation" - WEPPY asset category. Used by: upload, link, update. The link action does not support decal because it requires the backing Image asset ID.
+  - `displayName` - string - Roblox asset display name. Used by: upload, link, update.
 - Optional params:
   - `contextId` - string - Optional execution context identifier. Used to continue an existing context for mutating actions.
   - `contextSummary` - ExecutionContextSummary - Optional structured execution context attached to this tool call.
   - `replayMetadata` - ExecutionReplayMetadata - Optional replay-ready metadata attached to this tool call.
-  - `description` - string - Roblox asset description. Used by: upload, update.
+  - `scope` - "place" | "shared" - Asset Library scope. Used by: upload, link. Defaults to place.
+  - `placeId` - number - Asset Library Place ID. Used by: upload, link when scope is place. Defaults to the current runtime Place ID.
+  - `description` - string - Roblox asset description. Used by: upload, link, update.
   - `creatorType` - "user" | "group" - Asset creator owner type. Used by: upload, update. Defaults to saved credential metadata when available.
   - `creatorId` - string - User ID or group ID for the asset creator. Used by: upload, update. Defaults to saved credential metadata when available.
   - `expectedPrice` - number - Expected upload fee in Robux. Used by: upload, update when Roblox requires an expected price.
   - `waitForOperation` - boolean - When true, poll the returned Open Cloud operation until done or timeout. Used by: upload, update.
   - `operationPollTimeoutMs` - number - Maximum operation polling time in milliseconds. Used by: upload, update when waitForOperation is true.
   - `operationPollIntervalMs` - number - Operation polling interval in milliseconds. Used by: upload, update when waitForOperation is true.
+
+### `manage_open_cloud_assets.link`
+
+link an existing non-Decal Roblox asset ID and local source file to the Asset Library without creating another Roblox asset.
+
+- Tier: `pro`
+- Route: `internal`
+- Execution mode: `mutating`
+- Param aliases: none
+- Required params:
+  - `assetId` - string - Roblox asset ID. Used by: link (required), update (required), info (required).
+  - `filePath` - string - Local file path on the MCP server machine. Used by: upload, link, update.
+  - `category` - "image" | "decal" | "audio" | "mesh" | "model" | "video" | "animation" - WEPPY asset category. Used by: upload, link, update. The link action does not support decal because it requires the backing Image asset ID.
+- Optional params:
+  - `contextId` - string - Optional execution context identifier. Used to continue an existing context for mutating actions.
+  - `contextSummary` - ExecutionContextSummary - Optional structured execution context attached to this tool call.
+  - `replayMetadata` - ExecutionReplayMetadata - Optional replay-ready metadata attached to this tool call.
+  - `scope` - "place" | "shared" - Asset Library scope. Used by: upload, link. Defaults to place.
+  - `placeId` - number - Asset Library Place ID. Used by: upload, link when scope is place. Defaults to the current runtime Place ID.
+  - `displayName` - string - Roblox asset display name. Used by: upload, link, update.
+  - `description` - string - Roblox asset description. Used by: upload, link, update.
 
 ### `manage_open_cloud_assets.update`
 
@@ -2468,15 +2491,15 @@ update an existing Roblox asset through Open Cloud.
 - Execution mode: `mutating`
 - Param aliases: none
 - Required params:
-  - `assetId` - string - Roblox asset ID. Used by: update (required), info (required).
-  - `category` - "image" | "decal" | "audio" | "mesh" | "model" | "video" | "animation" - WEPPY asset category. Used by: upload, update.
+  - `assetId` - string - Roblox asset ID. Used by: link (required), update (required), info (required).
+  - `category` - "image" | "decal" | "audio" | "mesh" | "model" | "video" | "animation" - WEPPY asset category. Used by: upload, link, update. The link action does not support decal because it requires the backing Image asset ID.
 - Optional params:
   - `contextId` - string - Optional execution context identifier. Used to continue an existing context for mutating actions.
   - `contextSummary` - ExecutionContextSummary - Optional structured execution context attached to this tool call.
   - `replayMetadata` - ExecutionReplayMetadata - Optional replay-ready metadata attached to this tool call.
-  - `filePath` - string - Local file path on the MCP server machine. Used by: upload, update.
-  - `displayName` - string - Roblox asset display name. Used by: upload, update.
-  - `description` - string - Roblox asset description. Used by: upload, update.
+  - `filePath` - string - Local file path on the MCP server machine. Used by: upload, link, update.
+  - `displayName` - string - Roblox asset display name. Used by: upload, link, update.
+  - `description` - string - Roblox asset description. Used by: upload, link, update.
   - `creatorType` - "user" | "group" - Asset creator owner type. Used by: upload, update. Defaults to saved credential metadata when available.
   - `creatorId` - string - User ID or group ID for the asset creator. Used by: upload, update. Defaults to saved credential metadata when available.
   - `expectedPrice` - number - Expected upload fee in Robux. Used by: upload, update when Roblox requires an expected price.
@@ -2494,7 +2517,7 @@ read Roblox asset metadata through Open Cloud.
 - Execution mode: `readonly`
 - Param aliases: none
 - Required params:
-  - `assetId` - string - Roblox asset ID. Used by: update (required), info (required).
+  - `assetId` - string - Roblox asset ID. Used by: link (required), update (required), info (required).
 - Optional params:
   - `readMask` - array<string> - Asset metadata fields to retrieve. Used by: info.
 


### PR DESCRIPTION
## Release v2.12.4


### Features

- **Keep Open Cloud uploads in the Asset Library** — Uploading an image, audio file, model, or video through Open Cloud now creates or reuses the matching shared or Place asset record automatically. Existing non-Decal Roblox assets can also be linked to a local file without uploading them again, and repeated requests return the same library item.

### Bug Fixes

- **Resume Project Sync after its WebSocket reconnects** — If the local MCP server restarts or the command connection drops while Sync is active, the Studio plugin now reconnects, cleans up the previous session, and starts a fresh full sync with the same one-time or continuous intent, direction settings, and preserved-file choices.
- **Keep one stable folder for each Place during Sync** — Concurrent starts and Place ID promotion now use the same canonical folder. Duplicate folders are archived only after a successful full sync, so interrupted or failed syncs keep recoverable local data.
- **Keep Project Change Summary writes reliable on Windows** — Concurrent history writes and cleanup now share one file-access queue, preventing transient Windows rename locks from losing a session or stopping later cleanup work.
- **Reject unsafe Open Cloud library writes before local state changes** — Disabled uploads stop before creating a local library item, links require a verified matching Roblox asset type, and concurrent duplicate links converge on one item instead of producing duplicates.

### Stability

- **Safer local MCP restarts during Studio development** — The local stop script now targets only processes listening on the MCP ports, so an attached Roblox Studio client is not mistaken for the server.

---
Automated release from weppy-roblox-mcp-private