### PR TITLE
Release v2.13.4

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "WEPPY AI Agent Plugin marketplace for Codex — MCP setup and workflow guidance for the WEPPY Roblox AI Toolkit",
-    "version": "2.13.3"
+    "version": "2.13.4"
   },
   "plugins": [
     {
@@ -20,7 +20,7 @@
       },
       "category": "Coding",
       "description": "WEPPY AI Agent Plugin for Codex.",
-      "version": "2.13.3"
+      "version": "2.13.4"
     }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "WEPPY AI Agent Plugin marketplace for Claude Code — MCP setup and workflow guidance for the WEPPY Roblox AI Toolkit",
-    "version": "2.13.3"
+    "version": "2.13.4"
   },
   "plugins": [
     {
       "name": "weppy-roblox-ai-toolkit",
       "source": "./plugins/weppy-roblox-mcp",
       "description": "WEPPY AI Agent Plugin for Claude Code — MCP setup and workflow guidance for the WEPPY Roblox AI Toolkit.",
-      "version": "2.13.3",
+      "version": "2.13.4",
       "author": {
         "name": "hope1026"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,13 @@ All notable changes to this project will be documented in this file.
 
 
 
+
+## [2.13.4] - 2026-08-16
+
+### Stability
+
+- **Make connection-drop reports easier to diagnose** — Dashboard bug reports now include local, size-limited connection diagnostics that show whether the MCP server restarted or only the Roblox Studio Plugin reconnected. Sensitive free-form values and local paths are removed before these events are saved, and nothing is uploaded automatically. Update both the MCP server and Studio Plugin before reproducing an issue so the new `diagnostics.zip` contains both sides of the connection timeline.
+
 ## [2.13.3] - 2026-08-16
 
 ### Bug Fixes

--- a/plugins/weppy-roblox-mcp/.claude-plugin/plugin.json
+++ b/plugins/weppy-roblox-mcp/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "weppy-roblox-ai-toolkit",
   "description": "WEPPY AI Agent Plugin for Claude Code.",
-  "version": "2.13.3",
+  "version": "2.13.4",
   "author": {
     "name": "hope1026"
   },

--- a/plugins/weppy-roblox-mcp/.codex-plugin/plugin.json
+++ b/plugins/weppy-roblox-mcp/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "weppy-roblox-ai-toolkit",
-  "version": "2.13.3",
+  "version": "2.13.4",
   "description": "WEPPY AI Agent Plugin for Codex.",
   "author": {
     "name": "hope1026"


### PR DESCRIPTION
## Release v2.13.4


### Stability

- **Make connection-drop reports easier to diagnose** — Dashboard bug reports now include local, size-limited connection diagnostics that show whether the MCP server restarted or only the Roblox Studio Plugin reconnected. Sensitive free-form values and local paths are removed before these events are saved, and nothing is uploaded automatically. Update both the MCP server and Studio Plugin before reproducing an issue so the new `diagnostics.zip` contains both sides of the connection timeline.

---
Automated release from weppy-roblox-mcp-private