### PR TITLE
Release v2.13.6

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "WEPPY AI Agent Plugin marketplace for Codex — MCP setup and workflow guidance for the WEPPY Roblox AI Toolkit",
-    "version": "2.13.5"
+    "version": "2.13.6"
   },
   "plugins": [
     {
@@ -20,7 +20,7 @@
       },
       "category": "Coding",
       "description": "WEPPY AI Agent Plugin for Codex.",
-      "version": "2.13.5"
+      "version": "2.13.6"
     }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "WEPPY AI Agent Plugin marketplace for Claude Code — MCP setup and workflow guidance for the WEPPY Roblox AI Toolkit",
-    "version": "2.13.5"
+    "version": "2.13.6"
   },
   "plugins": [
     {
       "name": "weppy-roblox-ai-toolkit",
       "source": "./plugins/weppy-roblox-mcp",
       "description": "WEPPY AI Agent Plugin for Claude Code — MCP setup and workflow guidance for the WEPPY Roblox AI Toolkit.",
-      "version": "2.13.5",
+      "version": "2.13.6",
       "author": {
         "name": "hope1026"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,13 @@ All notable changes to this project will be documented in this file.
 
 
 
+
+## [2.13.6] - 2026-08-18
+
+### Features
+
+- **Measure Sync adoption without collecting project content** — With telemetry enabled, WEPPY now records whether Sync reaches its ready state and whether each Sync category is set to Studio-to-local, local-to-Studio, or bidirectional. It does not send project names, Place IDs, file paths, script source, apply results, failure rates, or change counts. Existing telemetry opt-out settings continue to apply, and no setup change is required.
+
 ## [2.13.5] - 2026-08-17
 
 ### Bug Fixes

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -33,6 +33,8 @@ Telemetry can include:
 - Locale and timezone
 - MCP server version
 - License tier label
+- Whether Sync reached its ready state
+- Sync category and active direction (`forward`, `reverse`, or `bidirectional`)
 - Approximate region derived by Google Analytics
 - Pseudonymous random device ID used to recognize repeat usage from the same local installation
 - A SHA-256-derived device observation key for server-side aggregate counting

--- a/plugins/weppy-roblox-mcp/.claude-plugin/plugin.json
+++ b/plugins/weppy-roblox-mcp/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "weppy-roblox-ai-toolkit",
   "description": "WEPPY AI Agent Plugin for Claude Code.",
-  "version": "2.13.5",
+  "version": "2.13.6",
   "author": {
     "name": "hope1026"
   },

--- a/plugins/weppy-roblox-mcp/.codex-plugin/plugin.json
+++ b/plugins/weppy-roblox-mcp/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "weppy-roblox-ai-toolkit",
-  "version": "2.13.5",
+  "version": "2.13.6",
   "description": "WEPPY AI Agent Plugin for Codex.",
   "author": {
     "name": "hope1026"


### PR DESCRIPTION
## Release v2.13.6


### Features

- **Measure Sync adoption without collecting project content** — With telemetry enabled, WEPPY now records whether Sync reaches its ready state and whether each Sync category is set to Studio-to-local, local-to-Studio, or bidirectional. It does not send project names, Place IDs, file paths, script source, apply results, failure rates, or change counts. Existing telemetry opt-out settings continue to apply, and no setup change is required.

---
Automated release from weppy-roblox-mcp-private