### PR TITLE
Release v2.14.4

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "WEPPY AI Agent Plugin marketplace for Codex — MCP setup and workflow guidance for the WEPPY Roblox AI Toolkit",
-    "version": "2.14.3"
+    "version": "2.14.4"
   },
   "plugins": [
     {
@@ -20,7 +20,7 @@
       },
       "category": "Coding",
       "description": "WEPPY AI Agent Plugin for Codex.",
-      "version": "2.14.3"
+      "version": "2.14.4"
     }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "WEPPY AI Agent Plugin marketplace for Claude Code — MCP setup and workflow guidance for the WEPPY Roblox AI Toolkit",
-    "version": "2.14.3"
+    "version": "2.14.4"
   },
   "plugins": [
     {
       "name": "weppy-roblox-ai-toolkit",
       "source": "./plugins/weppy-roblox-mcp",
       "description": "WEPPY AI Agent Plugin for Claude Code — MCP setup and workflow guidance for the WEPPY Roblox AI Toolkit.",
-      "version": "2.14.3",
+      "version": "2.14.4",
       "author": {
         "name": "hope1026"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,13 @@ All notable changes to this project will be documented in this file.
 
 
 
+
+## [2.14.4] - 2026-08-22
+
+### Stability
+
+- **Recover completed AI commands after Studio reconnects** — The Studio Plugin now keeps each completed command result until the MCP Server confirms receipt, then resends only unconfirmed results after a connection interruption. Completed tool calls no longer appear lost when the connection drops at the end of a command, and reconnects can recover several large pending results without exceeding the handshake message limit. No configuration change is required.
+
 ## [2.14.3] - 2026-08-22
 
 ### Features

--- a/plugins/weppy-roblox-mcp/.claude-plugin/plugin.json
+++ b/plugins/weppy-roblox-mcp/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "weppy-roblox-ai-toolkit",
   "description": "WEPPY AI Agent Plugin for Claude Code.",
-  "version": "2.14.3",
+  "version": "2.14.4",
   "author": {
     "name": "hope1026"
   },

--- a/plugins/weppy-roblox-mcp/.codex-plugin/plugin.json
+++ b/plugins/weppy-roblox-mcp/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "weppy-roblox-ai-toolkit",
-  "version": "2.14.3",
+  "version": "2.14.4",
   "description": "WEPPY AI Agent Plugin for Codex.",
   "author": {
     "name": "hope1026"


### PR DESCRIPTION
## Release v2.14.4


### Stability

- **Recover completed AI commands after Studio reconnects** — The Studio Plugin now keeps each completed command result until the MCP Server confirms receipt, then resends only unconfirmed results after a connection interruption. Completed tool calls no longer appear lost when the connection drops at the end of a command, and reconnects can recover several large pending results without exceeding the handshake message limit. No configuration change is required.

---
Automated release from weppy-roblox-mcp-private