### PR TITLE
Release v2.14.5

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "WEPPY AI Agent Plugin marketplace for Codex — MCP setup and workflow guidance for the WEPPY Roblox AI Toolkit",
-    "version": "2.14.4"
+    "version": "2.14.5"
   },
   "plugins": [
     {
@@ -20,7 +20,7 @@
       },
       "category": "Coding",
       "description": "WEPPY AI Agent Plugin for Codex.",
-      "version": "2.14.4"
+      "version": "2.14.5"
     }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "WEPPY AI Agent Plugin marketplace for Claude Code — MCP setup and workflow guidance for the WEPPY Roblox AI Toolkit",
-    "version": "2.14.4"
+    "version": "2.14.5"
   },
   "plugins": [
     {
       "name": "weppy-roblox-ai-toolkit",
       "source": "./plugins/weppy-roblox-mcp",
       "description": "WEPPY AI Agent Plugin for Claude Code — MCP setup and workflow guidance for the WEPPY Roblox AI Toolkit.",
-      "version": "2.14.4",
+      "version": "2.14.5",
       "author": {
         "name": "hope1026"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,13 @@ All notable changes to this project will be documented in this file.
 
 
 
+
+## [2.14.5] - 2026-08-22
+
+### Stability
+
+- **Keep npm releases available without expiring publisher tokens** — npm packages are now published through a short-lived GitHub identity tied to the protected release workflow. If npm publishing needs to be retried, the release can reuse the exact verified package archive without rebuilding the Studio Plugin or other release files. No installation or configuration change is required.
+
 ## [2.14.4] - 2026-08-22
 
 ### Stability

--- a/plugins/weppy-roblox-mcp/.claude-plugin/plugin.json
+++ b/plugins/weppy-roblox-mcp/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "weppy-roblox-ai-toolkit",
   "description": "WEPPY AI Agent Plugin for Claude Code.",
-  "version": "2.14.4",
+  "version": "2.14.5",
   "author": {
     "name": "hope1026"
   },

--- a/plugins/weppy-roblox-mcp/.codex-plugin/plugin.json
+++ b/plugins/weppy-roblox-mcp/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "weppy-roblox-ai-toolkit",
-  "version": "2.14.4",
+  "version": "2.14.5",
   "description": "WEPPY AI Agent Plugin for Codex.",
   "author": {
     "name": "hope1026"


### PR DESCRIPTION
## Release v2.14.5


### Stability

- **Keep npm releases available without expiring publisher tokens** — npm packages are now published through a short-lived GitHub identity tied to the protected release workflow. If npm publishing needs to be retried, the release can reuse the exact verified package archive without rebuilding the Studio Plugin or other release files. No installation or configuration change is required.

---
Automated release from weppy-roblox-mcp-private