### PR TITLE
Release v2.14.6

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "WEPPY AI Agent Plugin marketplace for Codex — MCP setup and workflow guidance for the WEPPY Roblox AI Toolkit",
-    "version": "2.14.5"
+    "version": "2.14.6"
   },
   "plugins": [
     {
@@ -20,7 +20,7 @@
       },
       "category": "Coding",
       "description": "WEPPY AI Agent Plugin for Codex.",
-      "version": "2.14.5"
+      "version": "2.14.6"
     }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "WEPPY AI Agent Plugin marketplace for Claude Code — MCP setup and workflow guidance for the WEPPY Roblox AI Toolkit",
-    "version": "2.14.5"
+    "version": "2.14.6"
   },
   "plugins": [
     {
       "name": "weppy-roblox-ai-toolkit",
       "source": "./plugins/weppy-roblox-mcp",
       "description": "WEPPY AI Agent Plugin for Claude Code — MCP setup and workflow guidance for the WEPPY Roblox AI Toolkit.",
-      "version": "2.14.5",
+      "version": "2.14.6",
       "author": {
         "name": "hope1026"
       },

--- a/.github/validation/skill-coverage.json
+++ b/.github/validation/skill-coverage.json
@@ -96,7 +96,7 @@
       "actions": [
         "manage_sync.status_current_place",
         "manage_sync.history",
-        "manage_sync.directions",
+        "manage_sync.policy",
         "manage_sync.read_file",
         "manage_sync.write_file",
         "manage_sync.progress"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,25 @@ All notable changes to this project will be documented in this file.
 
 
 
+
+## [2.14.6] - 2026-08-25
+
+### ⚠️ BREAKING CHANGES
+
+- **Update the MCP Server and Studio Plugin together** — Sync now requires both components to use the same WEPPY release. A version mismatch blocks the connection and Sync instead of continuing with incompatible behavior. Update both components to v2.14.6, then restart Roblox Studio. This compatibility check does not delete or reset project files.
+- **Review only Sync settings that cannot be converted safely** — Existing Sync on/off and start-on-connection values are preserved, and most saved direction settings are converted automatically. If an older setup combines several directions and automatic apply options in a way that has no safe workflow equivalent, Sync pauses to prevent unintended changes. Open the Studio Plugin's Sync tab and choose a workflow once to continue; the migration itself does not delete project files.
+- **Move Dashboard auto-open control out of the environment** — `DASHBOARD_AUTO_OPEN` is no longer used. Dashboard auto-open is now a saved setting, enabled by default, and changes take effect the next time the MCP Server starts. Dashboard history and project data are unchanged.
+
+### Features
+
+- **Set up Sync by workflow instead of individual directions** — Choose Studio First, Bidirectional Review, or Local Code + Studio World to configure the relevant Sync scopes and apply behavior together. Custom remains available when scripts, properties, structure, or service properties need separate control, and each control now explains its scope and availability.
+- **Start new Sync setups with safer defaults** — First-time setups begin with Sync and start-on-connection turned off, using Studio First as the default workflow. Deleting a local file affects the matching Studio instance only after the separate safety setting is explicitly enabled.
+- **Control Dashboard auto-open from Settings or your Agent** — Turn automatic opening on or off from the Dashboard Settings page, or ask an AI Agent to change the same saved setting without connecting Roblox Studio.
+
+### Stability
+
+- **Keep Studio connected when recent-place metadata cannot be saved** — A local metadata write failure after Plugin registration is now reported without interrupting the connection.
+
 ## [2.14.5] - 2026-08-22
 
 ### Stability

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -34,12 +34,14 @@ Telemetry can include:
 - MCP server version
 - License tier label
 - Whether Sync reached its ready state
-- Sync category and active direction (`forward`, `reverse`, or `bidirectional`)
+- Sync semantic scope in `sync_scope` (`scriptSource`, `properties`, `structure`, or `serviceProperties`) and active direction in `sync_direction` (`forward`, `reverse`, or `bidirectional`)
 - Approximate region derived by Google Analytics
 - Pseudonymous random device ID used to recognize repeat usage from the same local installation
 - A SHA-256-derived device observation key for server-side aggregate counting
 
 Command categories describe which WEPPY feature was used. They do not include your prompt text, script source, file path, or Roblox object path. License tier labels do not include the raw license key.
+
+Sync telemetry records a semantic scope only when that scope's effective direction changes. Sync workflow preset and delete-safety settings are not collected.
 
 ## Data Not Collected
 

--- a/README.md
+++ b/README.md
@@ -138,8 +138,11 @@ WEPPY Assets turns a natural-language asset request into a Studio-ready result.
 
 AI works from a synchronized local mirror, so multi-file updates stay consistent.
 
-- Basic: one-way sync (Studio -> Local)
-- Pro: bidirectional sync + per-type Direction/Apply Mode + history + up to five Places
+- Sync starts Off on first use. Start on connection is also Off. Saved settings always take precedence, including a saved Off value. The first-use workflow is Studio First, so the first synchronization treats Studio as the source.
+- Choose Studio First, Bidirectional Review, Local Code, Studio World, or Custom. Custom groups changes into four semantic scopes: Script Source, Properties, Structure, and Service Properties.
+- Content Changes and Structure Changes application modes are shown separately from scope direction. Local file deletion does not delete a Studio instance by default; applying a deletion to Studio requires an additional opt-in and is separate from UI Studio history cleanup.
+- Basic uses Studio-to-local Sync. Pro adds the richer workflow directions, history, and support for up to five Places.
+- The WEPPY MCP Server and WEPPY Roblox Studio Plugin must come from the same release. Update both together, then restart Roblox Studio before reconnecting if their versions do not match.
 
 ![Sync workflow - Studio and local files synchronized in real time](https://raw.githubusercontent.com/hope1026/weppy-roblox-mcp/main/docs/assets/screenshots/plugin/sync/sync-overview.png)
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -4,6 +4,12 @@
 
 The web dashboard includes a Connection topology for multiple AI agents, the MCP server, and multiple connected Studio Targets, with copyable Studio IDs and routing status for multi-Studio workflows.
 
+Sync starts Off on first use. Start on connection is also Off. Saved settings always take precedence, including explicitly saved Off and false values. The default first-use workflow is Studio First, so Studio is the source for the initial synchronization. The Studio plugin owns Sync start, stop, and policy editing; the MCP server and Dashboard expose the effective policy read-only.
+
+The workflows are Studio First, Bidirectional Review, Local Code, Studio World, and Custom. Custom uses the Script Source, Properties, Structure, and Service Properties semantic scopes. Content Changes and Structure Changes application modes are separate from scope direction. Local file deletion does not delete a Studio instance by default; applying it to Studio is an additional opt-in and is separate from UI Studio history cleanup. Basic is limited to Studio-to-local Sync, while Pro can use the additional workflow directions allowed by the effective policy.
+
+The WEPPY MCP Server and WEPPY Roblox Studio Plugin must come from the same release. Update both together, then restart Roblox Studio before reconnecting if their versions do not match.
+
 `manage_scripts.validate` provides Basic syntax validation for raw Luau source or an existing Script path without starting Playtest. The Dashboard setting at **Controls → Luau Syntax Validation** defaults to Off and enforces whether successful `set_source`, `edit_replace`, `edit_insert`, and `edit_delete` calls validate the actual saved source. Conflicting tool values are ignored with a warning that points to the Dashboard setting. Automatic valid checks keep the normal write response unchanged; invalid or unavailable checks add details, while an explicit matching `validate=true` requests full valid details. Validation never rolls back an applied write.
 
 The first request that needs WASM downloads the exact `luau-parser-v1.0.0` companion release and caches it locally; a compatible local `luau-compile` is the fallback. Source is parsed on the user's computer and is not sent to a remote validation service. If no parser is available, validation reports an unavailable status without turning a successful write into a failure. It checks only whether the Luau source parses.

--- a/llms.txt
+++ b/llms.txt
@@ -22,6 +22,14 @@ terrain, and more — inside a live Studio session.
 - Roblox Explorer VSCode extension for browsing Studio hierarchy
 - Works with Claude Code, Claude Desktop, Cursor, Codex CLI, Codex App, Gemini CLI, Antigravity / Antigravity IDE / Antigravity CLI
 
+## Sync policy and safety
+
+Sync starts Off on first use. Start on connection is also Off. Saved settings always take precedence, including explicitly saved Off and false values. The default first-use workflow is Studio First, with Studio as the source for the initial synchronization.
+
+The plugin offers Studio First, Bidirectional Review, Local Code, Studio World, and Custom workflows. Custom uses four semantic scopes: Script Source, Properties, Structure, and Service Properties. Content Changes and Structure Changes application modes are separate from those scope directions. Local file deletion does not delete a Studio instance by default; applying it to Studio requires an additional opt-in and is separate from UI Studio history cleanup. The Dashboard reports the effective policy read-only, while the Studio plugin owns Sync start, stop, and policy editing.
+
+The WEPPY MCP Server and WEPPY Roblox Studio Plugin must come from the same release. Update both together, then restart Roblox Studio before reconnecting if their versions do not match.
+
 ## Luau syntax validation
 
 `manage_scripts.validate` checks either raw source or an existing Script path and
@@ -93,8 +101,8 @@ Antigravity:
 
 ## Tiers
 
-- Basic (Free): MCP tool execution + one-way Studio -> Local sync
-- Pro: Bidirectional sync, UI Studio, bulk actions, terrain generation, spatial analysis, multi-place support for up to 5 places, advanced tools
+- Basic (Free): MCP tool execution + Studio-to-local sync
+- Pro: Additional Sync workflows, UI Studio, bulk actions, terrain generation, spatial analysis, multi-place support for up to 5 places, advanced tools
 
 ## Detailed docs
 

--- a/plugins/weppy-roblox-mcp/.claude-plugin/plugin.json
+++ b/plugins/weppy-roblox-mcp/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "weppy-roblox-ai-toolkit",
   "description": "WEPPY AI Agent Plugin for Claude Code.",
-  "version": "2.14.5",
+  "version": "2.14.6",
   "author": {
     "name": "hope1026"
   },

--- a/plugins/weppy-roblox-mcp/.codex-plugin/plugin.json
+++ b/plugins/weppy-roblox-mcp/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "weppy-roblox-ai-toolkit",
-  "version": "2.14.5",
+  "version": "2.14.6",
   "description": "WEPPY AI Agent Plugin for Codex.",
   "author": {
     "name": "hope1026"

--- a/plugins/weppy-roblox-mcp/skills/weppy-roblox-mcp-guide/references/mcp-actions.md
+++ b/plugins/weppy-roblox-mcp/skills/weppy-roblox-mcp-guide/references/mcp-actions.md
@@ -2540,7 +2540,7 @@ read Open Cloud operation status for upload/update processing.
 
 ## Tool: `manage_sync`
 
-[PRO] Project sync management: status, history, direction settings, read/write synced files.
+[PRO] Project sync management: status, history, effective policy, and synced file access.
 
 ### `manage_sync.status_current_place`
 
@@ -2563,20 +2563,20 @@ get change history.
 - Param aliases: none
 - Required params: none
 - Optional params:
-  - `placeId` - number - Place ID for sync operations. Used by: history, directions, read_file, write_file.
+  - `placeId` - number - Place ID for sync operations. Used by: history, policy, read_file, write_file.
   - `query` - object - Query parameters for history. Used by: history.
 
-### `manage_sync.directions`
+### `manage_sync.policy`
 
-get per-type sync directions.
+get the effective version 2 sync policy and capabilities.
 
 - Tier: `pro`
 - Route: `internal`
-- Execution mode: `unspecified`
+- Execution mode: `readonly`
 - Param aliases: none
 - Required params: none
 - Optional params:
-  - `placeId` - number - Place ID for sync operations. Used by: history, directions, read_file, write_file.
+  - `placeId` - number - Place ID for sync operations. Used by: history, policy, read_file, write_file.
 
 ### `manage_sync.read_file`
 
@@ -2587,7 +2587,7 @@ read a synced file.
 - Execution mode: `unspecified`
 - Param aliases: none
 - Required params:
-  - `placeId` - number - Place ID for sync operations. Used by: history, directions, read_file, write_file.
+  - `placeId` - number - Place ID for sync operations. Used by: history, policy, read_file, write_file.
   - `instancePath` - string - Instance path for file read/write. Used by: read_file, write_file.
 - Optional params: none
 
@@ -2600,7 +2600,7 @@ write to a synced file.
 - Execution mode: `unspecified`
 - Param aliases: none
 - Required params:
-  - `placeId` - number - Place ID for sync operations. Used by: history, directions, read_file, write_file.
+  - `placeId` - number - Place ID for sync operations. Used by: history, policy, read_file, write_file.
   - `instancePath` - string - Instance path for file read/write. Used by: read_file, write_file.
   - `content` - string - File content to write. Used by: write_file.
 - Optional params: none
@@ -2802,6 +2802,33 @@ quick access to recent errors only.
   - `placeId` - number - Optional Studio target selector. When multiple Studio clients are connected, route this call to the active client for this Roblox placeId. If no matching active client exists, the call fails instead of falling back to another Place.
   - `clientId` - string - Optional Studio target selector. Routes this call to the exact connected WEPPY Plugin client. Takes precedence over targetAlias and placeId.
   - `targetAlias` - string - Optional Studio target selector. Routes this call to the connected WEPPY Studio target alias shown in Dashboard/Plugin, such as studio-1. Takes precedence over placeId.
+
+## Tool: `manage_settings`
+
+WEPPY settings management. Read or change whether Dashboard opens automatically when the MCP Server starts.
+
+### `manage_settings.get_dashboard_auto_open`
+
+read the saved Dashboard auto-open preference.
+
+- Tier: `basic`
+- Route: `internal`
+- Execution mode: `readonly`
+- Param aliases: none
+- Required params: none
+- Optional params: none
+
+### `manage_settings.set_dashboard_auto_open`
+
+enable or disable Dashboard auto-open from the next MCP Server start.
+
+- Tier: `basic`
+- Route: `internal`
+- Execution mode: `mutating`
+- Param aliases: none
+- Required params:
+  - `enabled` - boolean - Whether Dashboard should open automatically when WEPPY MCP Server starts. Used by: set_dashboard_auto_open.
+- Optional params: none
 
 ## Tool: `system_info`
 

--- a/plugins/weppy-roblox-mcp/skills/weppy-roblox-sync-guide/SKILL.md
+++ b/plugins/weppy-roblox-mcp/skills/weppy-roblox-sync-guide/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: weppy-roblox-sync-guide
-description: Use when working with WEPPY Roblox MCP Studio-local sync, bidirectional file mirrors, sync directions, multi-place project folders, conflicts, reverse apply and delete safety, sourcemaps, detector recovery, or Roblox Explorer context.
+description: Use when working with WEPPY Roblox MCP Studio-local sync, effective policy, bidirectional file mirrors, multi-place project folders, conflicts, reverse apply and delete safety, sourcemaps, detector recovery, or Roblox Explorer context.
 ---
 
 # WEPPY Roblox Sync Guide
@@ -11,17 +11,18 @@ Use this skill when local files and Roblox Studio state must stay aligned throug
 
 ## Workflow
 
-1. Inspect current place and sync status before changing files or directions.
-2. Confirm the intended direction model: `forward`, `reverse`, or `bidirectional`.
-3. Use the v2 nested directory format when reading or editing mirrored files.
-4. Treat play mode as a sync suppression window; reconcile after play exits.
-5. Resolve conflicts according to direction policy, not by silently overwriting both sides.
-6. Confirm destructive local deletes before applying them to Studio unless delete auto-apply was explicitly enabled.
-7. Verify by checking sync status, changed files, sourcemaps, and Roblox Explorer when relevant.
+1. Inspect the current place with `manage_sync.status_current_place` and read the effective policy with `manage_sync.policy` before changing files.
+2. If Sync is Off or the effective policy does not allow the intended direction, explain the current state and ask the user to change it in the Studio plugin; policy editing stays in the Studio plugin.
+3. Confirm the relevant semantic scope and effective direction: `forward`, `reverse`, or `bidirectional`.
+4. Use the v2 nested directory format when reading or editing mirrored files.
+5. Treat play mode as a sync suppression window; reconcile after play exits.
+6. Resolve conflicts according to the effective policy, not by silently overwriting both sides.
+7. Confirm destructive local deletes before applying them to Studio unless delete auto-apply was explicitly enabled.
+8. Verify by checking sync status, changed files, sourcemaps, and Roblox Explorer when relevant.
 
 ## References
 
-- `references/sync-workflow.md`: status, directions, apply modes, and runtime lifecycle.
+- `references/sync-workflow.md`: status, effective policy, workflow scopes, apply modes, and runtime lifecycle.
 - `references/sync-format.md`: v2 nested directory and file naming rules.
 - `references/conflicts.md`: direction enforcement and conflict resolution.
 - `references/sourcemap.md`: Place sourcemaps and `luau-lsp` integration.
@@ -30,6 +31,7 @@ Use this skill when local files and Roblox Studio state must stay aligned throug
 ## Guardrails
 
 - Do not start sync while Studio is in play mode.
+- Do not claim that MCP or the Dashboard can edit Sync policy.
 - Do not migrate or delete old sync roots automatically.
 - Do not assume one active sync root per place; the project has one active `weppy-project-sync` root with isolated `place_*` children.
 - Do not treat `__MCP_*` temporary test instances as synced game content.

--- a/plugins/weppy-roblox-mcp/skills/weppy-roblox-sync-guide/references/sync-workflow.md
+++ b/plugins/weppy-roblox-mcp/skills/weppy-roblox-sync-guide/references/sync-workflow.md
@@ -4,36 +4,53 @@ WEPPY sync mirrors Roblox Studio content into local files under `weppy-project-s
 
 ## Lifecycle
 
-1. Check the connected place and sync status.
-2. Start full sync from Studio while Studio is in edit mode.
-3. Let incremental Studio changes flow to files according to direction policy.
-4. Let local file changes become reverse pending changes according to direction policy.
-5. Use sync history, progress, and read/write actions for inspection and targeted edits.
-6. Stop sync before changing project root or when Studio disconnects.
+1. Check the connected place with `manage_sync.status_current_place`.
+2. Read the effective version 2 policy and capabilities with `manage_sync.policy`.
+3. If Sync is Off, the user starts it from the Studio plugin while Studio is in edit mode. MCP and the Dashboard are read-only policy surfaces.
+4. Let incremental Studio changes flow to files according to the effective semantic scope direction.
+5. Let allowed local file changes become reverse pending changes according to the effective policy.
+6. Use Sync history, progress, and read/write actions for inspection and targeted edits.
+7. Stop Sync in the Studio plugin before changing project root or when Studio disconnects.
 
 ## Safe Defaults
 
-WEPPY is Studio-first by default: every category starts as `forward` with `manual` apply. Pro unlocks reverse and bidirectional choices but does not silently switch existing settings. Destructive local deletes stay manual unless the user explicitly enables delete auto-apply.
+Sync starts Off on first use. Start on connection is also Off, and the first-use workflow is Studio First. Saved settings always take precedence after the user saves a value, including explicit Off and false values. Basic resolves to the Studio-to-local capability; Pro can use additional directions without silently changing the stored policy.
+
+Local file deletion does not remove a Studio instance by default. Applying local deletion to Studio requires an additional opt-in, and that setting is separate from UI Studio history cleanup.
 
 ## Detector And Project Root Recovery
 
 Reverse detection uses a snapshot scanner, not an OS watcher. If status shows an inactive or suspended detector after full sync, run the supported manual rescan or restart path before editing local files. Changing the Dashboard project root stops active sync and starts a fresh full sync in the new root; it does not move or delete the previous sync directory.
 
-## Directions
+## Workflows And Semantic Scopes
+
+The Studio plugin offers these workflows:
+
+- Studio First
+- Bidirectional Review
+- Local Code, Studio World
+- Custom
+
+Custom configures these semantic scope keys:
+
+- `scriptSource`: Script source text.
+- `properties`: Instance properties, attributes, tags, and value content.
+- `structure`: Instance creation, deletion, reparenting, and ordering.
+- `serviceProperties`: supported root service properties.
 
 Direction values:
+
 - `forward`: Studio is authoritative.
 - `reverse`: local files are authoritative.
 - `bidirectional`: both sides can change; conflicts require resolution.
 
-Category keys:
-- `scripts`
-- `values`
-- `data`
-- `containers`
-- `services`
+Content Changes and Structure Changes application modes are reported separately from scope direction. Treat them as application behavior, not additional scopes.
 
-Default direction is `forward`. Default apply mode is `manual`. Basic tier forces safer manual behavior; Pro enables broader bidirectional workflows.
+Policy editing belongs to the Studio plugin. Use `manage_sync.policy` to explain the current effective policy and capability, but do not attempt to write it through MCP or the Dashboard.
+
+## Version Boundary
+
+The WEPPY MCP Server and WEPPY Roblox Studio Plugin must come from the same release and use command protocol version 4. If the connection reports a mismatch, do not start Sync. Tell the user to update both together and restart Roblox Studio before reconnecting.
 
 ## Multi-Place
 


### PR DESCRIPTION
## Release v2.14.6


### ⚠️ BREAKING CHANGES

- **Update the MCP Server and Studio Plugin together** — Sync now requires both components to use the same WEPPY release. A version mismatch blocks the connection and Sync instead of continuing with incompatible behavior. Update both components to v2.14.6, then restart Roblox Studio. This compatibility check does not delete or reset project files.
- **Review only Sync settings that cannot be converted safely** — Existing Sync on/off and start-on-connection values are preserved, and most saved direction settings are converted automatically. If an older setup combines several directions and automatic apply options in a way that has no safe workflow equivalent, Sync pauses to prevent unintended changes. Open the Studio Plugin's Sync tab and choose a workflow once to continue; the migration itself does not delete project files.
- **Move Dashboard auto-open control out of the environment** — `DASHBOARD_AUTO_OPEN` is no longer used. Dashboard auto-open is now a saved setting, enabled by default, and changes take effect the next time the MCP Server starts. Dashboard history and project data are unchanged.

### Features

- **Set up Sync by workflow instead of individual directions** — Choose Studio First, Bidirectional Review, or Local Code + Studio World to configure the relevant Sync scopes and apply behavior together. Custom remains available when scripts, properties, structure, or service properties need separate control, and each control now explains its scope and availability.
- **Start new Sync setups with safer defaults** — First-time setups begin with Sync and start-on-connection turned off, using Studio First as the default workflow. Deleting a local file affects the matching Studio instance only after the separate safety setting is explicitly enabled.
- **Control Dashboard auto-open from Settings or your Agent** — Turn automatic opening on or off from the Dashboard Settings page, or ask an AI Agent to change the same saved setting without connecting Roblox Studio.

### Stability

- **Keep Studio connected when recent-place metadata cannot be saved** — A local metadata write failure after Plugin registration is now reported without interrupting the connection.

---
Automated release from weppy-roblox-mcp-private