### PR TITLE
Release v2.15.0

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "WEPPY AI Agent Plugin marketplace for Codex — MCP setup and workflow guidance for the WEPPY Roblox AI Toolkit",
-    "version": "2.14.6"
+    "version": "2.15.0"
   },
   "plugins": [
     {
@@ -20,7 +20,7 @@
       },
       "category": "Coding",
       "description": "WEPPY AI Agent Plugin for Codex.",
-      "version": "2.14.6"
+      "version": "2.15.0"
     }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "WEPPY AI Agent Plugin marketplace for Claude Code — MCP setup and workflow guidance for the WEPPY Roblox AI Toolkit",
-    "version": "2.14.6"
+    "version": "2.15.0"
   },
   "plugins": [
     {
       "name": "weppy-roblox-ai-toolkit",
       "source": "./plugins/weppy-roblox-mcp",
       "description": "WEPPY AI Agent Plugin for Claude Code — MCP setup and workflow guidance for the WEPPY Roblox AI Toolkit.",
-      "version": "2.14.6",
+      "version": "2.15.0",
       "author": {
         "name": "hope1026"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,27 @@ All notable changes to this project will be documented in this file.
 
 
 
+
+## [2.15.0] - 2026-08-27
+
+### Features
+
+- **Keep Studio connected when an Agent session ends** — The Studio Plugin connection now belongs to a shared WEPPY Bridge instead of an individual AI Agent session. Closing or switching an Agent no longer shuts down that shared connection, reducing unnecessary reconnect waits and request retries. No settings change is required.
+- **See each connection boundary in Dashboard** — The Connection page now shows AI Agents, their per-session MCP Adapters, the shared WEPPY Bridge, and Studio Targets as separate connected roles, with the current state of each connection.
+
+### Bug Fixes
+
+- **Resume a paused Playtest after delayed Studio status updates** — A stale running observation no longer overwrites the requested paused state before the resume command is processed.
+- **Keep required responsive checks in UI Studio reviews** — UI Studio now preserves a design's required screen-size review setting through its check summary, so unfinished required coverage remains visible instead of being treated as optional.
+- **Use terrain fill materials without misleading warnings** — Block, ball, cylinder, and wedge terrain fills now recognize the selected material as a valid option instead of reporting it as unused.
+- **Resolve animation controls from Model paths** — Animation track requests now find a Model's Humanoid or AnimationController, while direct controller paths continue to work.
+- **Explain Studio asset upload failures more clearly** — When Roblox Studio cannot run an asset upload, WEPPY now returns the failure stage and actionable guidance instead of an ambiguous error.
+
+### Stability
+
+- **Recover the shared Studio connection after a Bridge failure** — An active Agent automatically restores an unexpectedly stopped WEPPY Bridge and waits for the Studio Plugin to reconnect before handling the next request. A change command whose completion cannot be confirmed is not repeated automatically, preventing the same change from being applied twice.
+- **Coordinate multiple Agent sessions through one verified Bridge** — Concurrent Agents now discover and share the same authenticated local runtime instead of competing for the Studio connection. Startup, shutdown, and stale runtime recovery use the same ownership checks on macOS and Windows.
+
 ## [2.14.6] - 2026-08-25
 
 ### ⚠️ BREAKING CHANGES

--- a/plugins/weppy-roblox-mcp/.claude-plugin/plugin.json
+++ b/plugins/weppy-roblox-mcp/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "weppy-roblox-ai-toolkit",
   "description": "WEPPY AI Agent Plugin for Claude Code.",
-  "version": "2.14.6",
+  "version": "2.15.0",
   "author": {
     "name": "hope1026"
   },

--- a/plugins/weppy-roblox-mcp/.codex-plugin/plugin.json
+++ b/plugins/weppy-roblox-mcp/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "weppy-roblox-ai-toolkit",
-  "version": "2.14.6",
+  "version": "2.15.0",
   "description": "WEPPY AI Agent Plugin for Codex.",
   "author": {
     "name": "hope1026"

--- a/plugins/weppy-roblox-mcp/skills/weppy-roblox-mcp-guide/references/mcp-actions.md
+++ b/plugins/weppy-roblox-mcp/skills/weppy-roblox-mcp-guide/references/mcp-actions.md
@@ -1624,6 +1624,7 @@ enable or disable a ParticleEmitter, Beam, Trail, or other effect.
 - Optional params:
   - `cframe` - object - Position and rotation for fill shapes. Used by: fill_block, fill_cylinder, fill_wedge.
   - `size` - object - Size in studs. Used by: fill_block, fill_wedge.
+  - `material` - string - Terrain material name (e.g., Grass, Rock, Water, Sand, Slate, Concrete). Used by: fill_*, replace_material, colors_get, colors_set.
   - `placeId` - number - Optional Studio target selector. When multiple Studio clients are connected, route this call to the active client for this Roblox placeId. If no matching active client exists, the call fails instead of falling back to another Place.
   - `clientId` - string - Optional Studio target selector. Routes this call to the exact connected WEPPY Plugin client. Takes precedence over targetAlias and placeId.
   - `targetAlias` - string - Optional Studio target selector. Routes this call to the connected WEPPY Studio target alias shown in Dashboard/Plugin, such as studio-1. Takes precedence over placeId.
@@ -1638,6 +1639,7 @@ enable or disable a ParticleEmitter, Beam, Trail, or other effect.
 - Optional params:
   - `center` - object - Center position as Vector3. Used by: fill_ball.
   - `radius` - number - Radius in studs. Used by: fill_ball, fill_cylinder.
+  - `material` - string - Terrain material name (e.g., Grass, Rock, Water, Sand, Slate, Concrete). Used by: fill_*, replace_material, colors_get, colors_set.
   - `placeId` - number - Optional Studio target selector. When multiple Studio clients are connected, route this call to the active client for this Roblox placeId. If no matching active client exists, the call fails instead of falling back to another Place.
   - `clientId` - string - Optional Studio target selector. Routes this call to the exact connected WEPPY Plugin client. Takes precedence over targetAlias and placeId.
   - `targetAlias` - string - Optional Studio target selector. Routes this call to the connected WEPPY Studio target alias shown in Dashboard/Plugin, such as studio-1. Takes precedence over placeId.
@@ -1653,6 +1655,7 @@ enable or disable a ParticleEmitter, Beam, Trail, or other effect.
   - `cframe` - object - Position and rotation for fill shapes. Used by: fill_block, fill_cylinder, fill_wedge.
   - `radius` - number - Radius in studs. Used by: fill_ball, fill_cylinder.
   - `height` - number - Height in studs. Used by: fill_cylinder.
+  - `material` - string - Terrain material name (e.g., Grass, Rock, Water, Sand, Slate, Concrete). Used by: fill_*, replace_material, colors_get, colors_set.
   - `placeId` - number - Optional Studio target selector. When multiple Studio clients are connected, route this call to the active client for this Roblox placeId. If no matching active client exists, the call fails instead of falling back to another Place.
   - `clientId` - string - Optional Studio target selector. Routes this call to the exact connected WEPPY Plugin client. Takes precedence over targetAlias and placeId.
   - `targetAlias` - string - Optional Studio target selector. Routes this call to the connected WEPPY Studio target alias shown in Dashboard/Plugin, such as studio-1. Takes precedence over placeId.
@@ -1669,6 +1672,7 @@ fill shapes with material. clear_region/clear_bounds: clear terrain. replace_mat
 - Optional params:
   - `cframe` - object - Position and rotation for fill shapes. Used by: fill_block, fill_cylinder, fill_wedge.
   - `size` - object - Size in studs. Used by: fill_block, fill_wedge.
+  - `material` - string - Terrain material name (e.g., Grass, Rock, Water, Sand, Slate, Concrete). Used by: fill_*, replace_material, colors_get, colors_set.
   - `placeId` - number - Optional Studio target selector. When multiple Studio clients are connected, route this call to the active client for this Roblox placeId. If no matching active client exists, the call fails instead of falling back to another Place.
   - `clientId` - string - Optional Studio target selector. Routes this call to the exact connected WEPPY Plugin client. Takes precedence over targetAlias and placeId.
   - `targetAlias` - string - Optional Studio target selector. Routes this call to the connected WEPPY Studio target alias shown in Dashboard/Plugin, such as studio-1. Takes precedence over placeId.


### PR DESCRIPTION
## Release v2.15.0


### Features

- **Keep Studio connected when an Agent session ends** — The Studio Plugin connection now belongs to a shared WEPPY Bridge instead of an individual AI Agent session. Closing or switching an Agent no longer shuts down that shared connection, reducing unnecessary reconnect waits and request retries. No settings change is required.
- **See each connection boundary in Dashboard** — The Connection page now shows AI Agents, their per-session MCP Adapters, the shared WEPPY Bridge, and Studio Targets as separate connected roles, with the current state of each connection.

### Bug Fixes

- **Resume a paused Playtest after delayed Studio status updates** — A stale running observation no longer overwrites the requested paused state before the resume command is processed.
- **Keep required responsive checks in UI Studio reviews** — UI Studio now preserves a design's required screen-size review setting through its check summary, so unfinished required coverage remains visible instead of being treated as optional.
- **Use terrain fill materials without misleading warnings** — Block, ball, cylinder, and wedge terrain fills now recognize the selected material as a valid option instead of reporting it as unused.
- **Resolve animation controls from Model paths** — Animation track requests now find a Model's Humanoid or AnimationController, while direct controller paths continue to work.
- **Explain Studio asset upload failures more clearly** — When Roblox Studio cannot run an asset upload, WEPPY now returns the failure stage and actionable guidance instead of an ambiguous error.

### Stability

- **Recover the shared Studio connection after a Bridge failure** — An active Agent automatically restores an unexpectedly stopped WEPPY Bridge and waits for the Studio Plugin to reconnect before handling the next request. A change command whose completion cannot be confirmed is not repeated automatically, preventing the same change from being applied twice.
- **Coordinate multiple Agent sessions through one verified Bridge** — Concurrent Agents now discover and share the same authenticated local runtime instead of competing for the Studio connection. Startup, shutdown, and stale runtime recovery use the same ownership checks on macOS and Windows.

---
Automated release from weppy-roblox-mcp-private