### PR TITLE
Release v2.16.0

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "WEPPY AI Agent Plugin marketplace for Codex — MCP setup and workflow guidance for the WEPPY Roblox AI Toolkit",
-    "version": "2.15.1"
+    "version": "2.16.0"
   },
   "plugins": [
     {
@@ -20,7 +20,7 @@
       },
       "category": "Coding",
       "description": "WEPPY AI Agent Plugin for Codex.",
-      "version": "2.15.1"
+      "version": "2.16.0"
     }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "WEPPY AI Agent Plugin marketplace for Claude Code — MCP setup and workflow guidance for the WEPPY Roblox AI Toolkit",
-    "version": "2.15.1"
+    "version": "2.16.0"
   },
   "plugins": [
     {
       "name": "weppy-roblox-ai-toolkit",
       "source": "./plugins/weppy-roblox-mcp",
       "description": "WEPPY AI Agent Plugin for Claude Code — MCP setup and workflow guidance for the WEPPY Roblox AI Toolkit.",
-      "version": "2.15.1",
+      "version": "2.16.0",
       "author": {
         "name": "hope1026"
       },

--- a/.github/validation/skill-coverage.json
+++ b/.github/validation/skill-coverage.json
@@ -75,6 +75,9 @@
         "manage_studio.play_pause",
         "manage_studio.play_resume",
         "manage_studio.play_status",
+        "manage_studio.test_session_start",
+        "manage_studio.test_session_status",
+        "manage_studio.test_session_stop",
         "manage_studio.run_test"
       ]
     },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,21 @@ All notable changes to this project will be documented in this file.
 
 
 
+
+## [2.16.0] - 2026-08-29
+
+### Features
+
+- **Test the player screen and server results in one Playtest** — AI agents can now run separate client and server checks in the same session, so they can verify visible UI, text, layout, locale, and player-facing behavior alongside authoritative gameplay state instead of relying only on injected server-side Luau and logs. Existing Raw Luau checks remain available for project-specific assertions, and no settings change is required.
+- **Review structured Playtest evidence in Dashboard** — Each recorded run now shows its steps, client or server context, expected and observed values, test dimensions, artifacts, and failure details. You can see why a check passed or failed without reconstructing the result from raw output logs.
+
+### Bug Fixes
+
+- **Keep optional observations from failing required checks** — Missing optional evidence no longer changes a successful required check into a failure, while genuine required failures still determine the final result.
+- **Preserve client-side failures in the final report** — Locale and environment observation errors no longer disappear when a Playtest ends, making client-specific failures visible to both the AI agent and Dashboard.
+- **Report real timeout durations and recover cleanly between runs** — Timed-out Raw Luau checks now retain their elapsed duration, and consecutive Playtest sessions no longer inherit stale interaction state from the previous run.
+- **Record screen-size evidence without serialization errors** — Client checks can now return viewport dimensions as structured evidence without failing on Roblox vector values.
+
 ## [2.15.1] - 2026-08-27
 
 ### Bug Fixes

--- a/README.md
+++ b/README.md
@@ -160,11 +160,13 @@ The first validation that needs the companion parser downloads the exact `luau-p
 
 ### 6) Playtest: Let AI run and verify tests automatically
 
-AI can control Roblox Studio playtests directly. It can start and stop Play (F5) or Run (F8), inject test scripts, collect logs, and generate local reports automatically.
+Ordinary runtime checks use a structured Play session. AI can wait for game UI, inspect its semantic structure and geometry, deliver virtual input, observe the UI response, and verify the resulting server state in separate evidence steps. The local Dashboard groups the saved result by server, client UI, interaction, and visual evidence so you can review what passed and why.
 
-- "Start a Run-mode playtest and check whether the NPC reaches the target."
-- "Write a test that verifies the SpawnLocation is above the ground and run it."
-- "Validate that the script I just changed runs without errors in playtest."
+- "Start a Playtest, press the Start button, and verify the round begins on the server."
+- "Check that the HUD appears and the selected card activates after input."
+- "Validate that the script I just changed runs without errors in Playtest."
+
+Run mode is reserved for an explicitly requested server-only check. Raw Luau remains available as an advanced explicit opt-in for diagnostics that do not fit the structured steps. Play-mode screenshot capture is not supported; UI structure, geometry, input delivery, activation, and server observations are recorded instead. Reports stay local, existing Raw Luau reports remain readable, and no setting change is required.
 
 ![WEPPY Playtest Dashboard - Test history and detailed report](https://raw.githubusercontent.com/hope1026/weppy-roblox-mcp/main/docs/assets/screenshots/dashboard/dashboard_playtest.png)
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -14,6 +14,8 @@ The WEPPY MCP Server and WEPPY Roblox Studio Plugin must come from the same rele
 
 The first request that needs WASM downloads the exact `luau-parser-v1.0.0` companion release and caches it locally; a compatible local `luau-compile` is the fallback. Source is parsed on the user's computer and is not sent to a remote validation service. If no parser is available, validation reports an unavailable status without turning a successful write into a failure. It checks only whether the Luau source parses.
 
+Ordinary runtime verification uses a structured Play session. The AI can wait for UI, inspect semantic structure and geometry, deliver virtual input, observe activation separately, and verify the server result in another step. The local Dashboard groups saved evidence by server, client UI, interaction, and visual status. Run mode is for an explicitly requested server-only check. Raw Luau is an advanced explicit opt-in when a diagnostic does not fit the structured steps. Play-mode screenshot capture is not supported; semantic UI, input delivery, activation, and server observations are recorded instead. Existing Raw Luau reports remain readable and no setting change is required.
+
 This package intentionally does not ship a standalone full documentation surface.
 
 Canonical documentation lives on the web:

--- a/llms.txt
+++ b/llms.txt
@@ -15,7 +15,7 @@ terrain, and more — inside a live Studio session.
 - Action-based MCP tools covering the full Roblox Studio API surface
 - Basic Luau syntax validation for raw source or an existing Script without starting Playtest
 - Bidirectional project sync between Roblox Studio and local files (Pro)
-- Automated playtest: AI starts/stops Play/Run, injects test scripts, collects logs
+- Structured Playtest: ordinary checks use Play and record UI, input, and server evidence locally
 - UI Studio: AI creates in-game UI that matches your game's style or analyzes existing UI and suggests improvements
 - Web dashboard: monitor AI actions, tool history, sync state, changelog, and multi-agent / multi-Studio Connection topology with Studio Targets at `http://localhost:3002`
 - Multi-place support (up to 5 places simultaneously)
@@ -50,6 +50,20 @@ full valid details too. The first request that needs WASM downloads the exact
 not sent to a remote validation service. If no parser is available, the action
 reports validation as unavailable without turning a successful write into a
 failure.
+
+## Playtest verification
+
+Ordinary runtime verification uses a structured Play session. The AI can wait
+for UI, inspect semantic structure and geometry, deliver virtual input, observe
+activation separately, and verify the server result in another step. The local
+Dashboard groups saved evidence by server, client UI, interaction, and visual
+status.
+
+Run mode is for an explicitly requested server-only check. Raw Luau is an
+advanced explicit opt-in when a diagnostic does not fit the structured steps.
+Play-mode screenshot capture is not supported; semantic UI, input delivery,
+activation, and server observations are recorded instead. Existing Raw Luau
+reports remain readable and no setting change is required.
 
 ## Installation
 

--- a/plugins/weppy-roblox-mcp/.claude-plugin/plugin.json
+++ b/plugins/weppy-roblox-mcp/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "weppy-roblox-ai-toolkit",
   "description": "WEPPY AI Agent Plugin for Claude Code.",
-  "version": "2.15.1",
+  "version": "2.16.0",
   "author": {
     "name": "hope1026"
   },

--- a/plugins/weppy-roblox-mcp/.codex-plugin/plugin.json
+++ b/plugins/weppy-roblox-mcp/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "weppy-roblox-ai-toolkit",
-  "version": "2.15.1",
+  "version": "2.16.0",
   "description": "WEPPY AI Agent Plugin for Codex.",
   "author": {
     "name": "hope1026"

--- a/plugins/weppy-roblox-mcp/skills/weppy-roblox-mcp-guide/references/mcp-actions.md
+++ b/plugins/weppy-roblox-mcp/skills/weppy-roblox-mcp-guide/references/mcp-actions.md
@@ -2946,7 +2946,7 @@ Control Roblox Studio state for playtest lifecycle, automated test runs, and edi
 - Execution mode: `unspecified`
 - Param aliases: none
 - Required params:
-  - `testProfile` - StudioTestProfile - Optional Player Emulator test profile patch. Used by: test_profile_set, play_start, run_test.
+  - `testProfile` - StudioTestProfile - Optional Player Emulator test profile patch. Used by: test_profile_set, play_start, test_session_start, run_test.
 - Optional params:
   - `placeId` - number - Optional Studio target selector. When multiple Studio clients are connected, route this call to the active client for this Roblox placeId. If no matching active client exists, the call fails instead of falling back to another Place.
   - `clientId` - string - Optional Studio target selector. Routes this call to the exact connected WEPPY Plugin client. Takes precedence over targetAlias and placeId.
@@ -2998,8 +2998,8 @@ Control Roblox Studio state for playtest lifecycle, automated test runs, and edi
 - Required params: none
 - Optional params:
   - `mode` - "play" | "run" - Playtest mode. "play" = Play mode (F5, default), "run" = Run mode (F8). Used by: play_start, run_test.
-  - `testProfile` - StudioTestProfile - Optional Player Emulator test profile patch. Used by: test_profile_set, play_start, run_test.
-  - `restoreAfterTest` - boolean - Restore the profile snapshot after the play session or automated test finishes. Defaults to true when testProfile is provided. Used by: play_start, run_test.
+  - `testProfile` - StudioTestProfile - Optional Player Emulator test profile patch. Used by: test_profile_set, play_start, test_session_start, run_test.
+  - `restoreAfterTest` - boolean - Restore the profile snapshot after the play session or automated test finishes. Defaults to true when testProfile is provided. Used by: play_start, test_session_start, run_test.
   - `placeId` - number - Optional Studio target selector. When multiple Studio clients are connected, route this call to the active client for this Roblox placeId. If no matching active client exists, the call fails instead of falling back to another Place.
   - `clientId` - string - Optional Studio target selector. Routes this call to the exact connected WEPPY Plugin client. Takes precedence over targetAlias and placeId.
   - `targetAlias` - string - Optional Studio target selector. Routes this call to the connected WEPPY Studio target alias shown in Dashboard/Plugin, such as studio-1. Takes precedence over placeId.
@@ -3052,20 +3052,75 @@ Control Roblox Studio state for playtest lifecycle, automated test runs, and edi
   - `clientId` - string - Optional Studio target selector. Routes this call to the exact connected WEPPY Plugin client. Takes precedence over targetAlias and placeId.
   - `targetAlias` - string - Optional Studio target selector. Routes this call to the connected WEPPY Studio target alias shown in Dashboard/Plugin, such as studio-1. Takes precedence over placeId.
 
-### `manage_studio.run_test`
+### `manage_studio.test_session_start`
+
+Start a structured Play-default test session after complete preflight validation.
 
 - Tier: `pro`
 - Route: `internal`
 - Execution mode: `unspecified`
 - Param aliases: none
 - Required params:
-  - `script` - string - Luau test body to inject into ServerScriptService.__MCP_TestRunner. Used by: run_test.
+  - `scenario` - TestSessionScenario - Structured protocol v1 scenario. Mode defaults to play and clients defaults to one. Used by: test_session_start.
+- Optional params:
+  - `idempotencyKey` - string - Optional idempotency key scoped to the pinned Studio target and normalized scenario. Used by: test_session_start.
+  - `testProfile` - StudioTestProfile - Optional Player Emulator test profile patch. Used by: test_profile_set, play_start, test_session_start, run_test.
+  - `restoreAfterTest` - boolean - Restore the profile snapshot after the play session or automated test finishes. Defaults to true when testProfile is provided. Used by: play_start, test_session_start, run_test.
+  - `placeId` - number - Optional Studio target selector. When multiple Studio clients are connected, route this call to the active client for this Roblox placeId. If no matching active client exists, the call fails instead of falling back to another Place.
+  - `clientId` - string - Optional Studio target selector. Routes this call to the exact connected WEPPY Plugin client. Takes precedence over targetAlias and placeId.
+  - `targetAlias` - string - Optional Studio target selector. Routes this call to the connected WEPPY Studio target alias shown in Dashboard/Plugin, such as studio-1. Takes precedence over placeId.
+  - `contextId` - string - Optional execution context identifier. Used to continue an existing context for mutating actions.
+  - `contextSummary` - ExecutionContextSummary - Optional structured execution context attached to this tool call.
+  - `replayMetadata` - ExecutionReplayMetadata - Optional replay-ready metadata attached to this tool call.
+
+### `manage_studio.test_session_status`
+
+Read a bounded page of structured test session status and step evidence.
+
+- Tier: `pro`
+- Route: `internal`
+- Execution mode: `readonly`
+- Param aliases: none
+- Required params:
+  - `sessionId` - string - Structured test session identifier returned by test_session_start. Used by: test_session_status, test_session_stop.
+- Optional params:
+  - `stepCursor` - string - Optional opaque cursor returned by a previous status page. Used by: test_session_status.
+  - `stepLimit` - integer - Maximum step evidence entries in one status page. Defaults to 20 and cannot exceed 50. Used by: test_session_status.
+  - `placeId` - number - Optional Studio target selector. When multiple Studio clients are connected, route this call to the active client for this Roblox placeId. If no matching active client exists, the call fails instead of falling back to another Place.
+  - `clientId` - string - Optional Studio target selector. Routes this call to the exact connected WEPPY Plugin client. Takes precedence over targetAlias and placeId.
+  - `targetAlias` - string - Optional Studio target selector. Routes this call to the connected WEPPY Studio target alias shown in Dashboard/Plugin, such as studio-1. Takes precedence over placeId.
+
+### `manage_studio.test_session_stop`
+
+Request cancellation and bounded teardown for a structured test session.
+
+- Tier: `pro`
+- Route: `internal`
+- Execution mode: `unspecified`
+- Param aliases: none
+- Required params:
+  - `sessionId` - string - Structured test session identifier returned by test_session_start. Used by: test_session_status, test_session_stop.
+- Optional params:
+  - `placeId` - number - Optional Studio target selector. When multiple Studio clients are connected, route this call to the active client for this Roblox placeId. If no matching active client exists, the call fails instead of falling back to another Place.
+  - `clientId` - string - Optional Studio target selector. Routes this call to the exact connected WEPPY Plugin client. Takes precedence over targetAlias and placeId.
+  - `targetAlias` - string - Optional Studio target selector. Routes this call to the connected WEPPY Studio target alias shown in Dashboard/Plugin, such as studio-1. Takes precedence over placeId.
+
+### `manage_studio.run_test`
+
+Legacy explicit opt-in executionKind="raw_luau" runner. Do not select it for ordinary structured test requests.
+
+- Tier: `pro`
+- Route: `internal`
+- Execution mode: `unspecified`
+- Param aliases: none
+- Required params:
+  - `script` - string - Luau test body for the explicit legacy opt-in executionKind="raw_luau" path. It is injected into ServerScriptService.__MCP_TestRunner. Used by: run_test only.
 - Optional params:
   - `mode` - "play" | "run" - Playtest mode. "play" = Play mode (F5, default), "run" = Run mode (F8). Used by: play_start, run_test.
   - `test_name` - string - Optional report display name for the automated playtest run. Used by: run_test.
   - `timeout` - number - Timeout in seconds for the automated playtest run. Default: 60. Maximum: 300. Used by: run_test.
-  - `testProfile` - StudioTestProfile - Optional Player Emulator test profile patch. Used by: test_profile_set, play_start, run_test.
-  - `restoreAfterTest` - boolean - Restore the profile snapshot after the play session or automated test finishes. Defaults to true when testProfile is provided. Used by: play_start, run_test.
+  - `testProfile` - StudioTestProfile - Optional Player Emulator test profile patch. Used by: test_profile_set, play_start, test_session_start, run_test.
+  - `restoreAfterTest` - boolean - Restore the profile snapshot after the play session or automated test finishes. Defaults to true when testProfile is provided. Used by: play_start, test_session_start, run_test.
   - `placeId` - number - Optional Studio target selector. When multiple Studio clients are connected, route this call to the active client for this Roblox placeId. If no matching active client exists, the call fails instead of falling back to another Place.
   - `clientId` - string - Optional Studio target selector. Routes this call to the exact connected WEPPY Plugin client. Takes precedence over targetAlias and placeId.
   - `targetAlias` - string - Optional Studio target selector. Routes this call to the connected WEPPY Studio target alias shown in Dashboard/Plugin, such as studio-1. Takes precedence over placeId.

--- a/plugins/weppy-roblox-mcp/skills/weppy-roblox-mcp-guide/references/playtest.md
+++ b/plugins/weppy-roblox-mcp/skills/weppy-roblox-mcp-guide/references/playtest.md
@@ -9,7 +9,10 @@ Use playtest actions when verifying runtime behavior, collecting logs, or creati
 - `manage_studio.play_pause`: pause a running playtest.
 - `manage_studio.play_resume`: resume a paused playtest.
 - `manage_studio.play_stop`: stop a playtest.
-- `manage_studio.run_test`: inject a Luau test body, run playtest, collect logs, and write report files.
+- `manage_studio.test_session_start`: start a structured test session. It defaults to Play mode and one client.
+- `manage_studio.test_session_status`: read bounded progress and step evidence without copying the full result.
+- `manage_studio.test_session_stop`: cancel a structured session and request teardown.
+- `manage_studio.run_test`: use the legacy `executionKind="raw_luau"` path as an explicit advanced diagnostic opt-in.
 
 ## Locale Test Environment
 
@@ -23,13 +26,21 @@ Player Emulator settings and the in-experience language are separate capabilitie
 
 The stable plugin does not use private Player Emulator services or CoreGui input automation. When no public profile provider or opted-in language adapter is available, set operations return structured `test_profile_manual_required` or `experience_language_manual_required` failures. Do not treat requested values as applied values.
 
-`manage_studio.play_start` and `manage_studio.run_test` accept an optional `testProfile` patch and `restoreAfterTest`. Profile application must succeed before play starts. With restoration enabled, the selected Studio target's snapshot is restored on success, error, timeout, or cancellation. Use `manage_studio.play_status` to inspect `activeTestProfileResult` and `lastTestProfileResult` for a manually started play session.
+`manage_studio.play_start`, `manage_studio.test_session_start`, and `manage_studio.run_test` accept an optional `testProfile` patch and `restoreAfterTest`. Profile application must succeed before play starts. With restoration enabled, the selected Studio target's snapshot is restored on success, error, timeout, or cancellation. Use `manage_studio.play_status` to inspect `activeTestProfileResult` and `lastTestProfileResult` for a manually started play session.
 
 Read `mcp-actions.md` for exact params and tiers.
 
-## Automated Test Runner
+## Structured Test Session
 
-`manage_studio.run_test` requires `script`. Optional fields include `mode`, `test_name`, `timeout`, `testProfile`, `restoreAfterTest`, `contextId`, `contextSummary`, and `replayMetadata`.
+For ordinary runtime verification, use `test_session_start`. It defaults to Play mode with one client. The scenario is JSON-compatible data, runs sequential steps, and never carries a Luau function body. Choose Run only for an explicit server-only scenario.
+
+Poll `test_session_status` with the returned `sessionId`. The default page contains at most 20 step entries; `stepLimit` cannot exceed 50. Use the opaque `stepCursor` for the next page. Call `test_session_stop` to cancel a non-terminal session.
+
+For UI interaction checks, wait for the target UI, capture semantic UI structure and geometry, then use VirtualInput. Keep input delivery and `GuiButton.Activated` observation as separate evidence, and verify server effects in a separate server step. Play-mode screenshot capture is not supported, so do not substitute screenshot evidence for semantic UI or interaction evidence.
+
+## Legacy Raw Luau Runner
+
+`manage_studio.run_test` requires `script` and represents the Raw Luau explicit advanced diagnostic opt-in. Optional fields include `mode`, `test_name`, `timeout`, `testProfile`, `restoreAfterTest`, `contextId`, `contextSummary`, and `replayMetadata`.
 
 The runner wraps the user script, emits `[WEPPY_TEST]` log signals, collects `manage_logs` output, stops playtest during cleanup, and stores report artifacts under the active place test directory.
 


### PR DESCRIPTION
## Release v2.16.0


### Features

- **Test the player screen and server results in one Playtest** — AI agents can now run separate client and server checks in the same session, so they can verify visible UI, text, layout, locale, and player-facing behavior alongside authoritative gameplay state instead of relying only on injected server-side Luau and logs. Existing Raw Luau checks remain available for project-specific assertions, and no settings change is required.
- **Review structured Playtest evidence in Dashboard** — Each recorded run now shows its steps, client or server context, expected and observed values, test dimensions, artifacts, and failure details. You can see why a check passed or failed without reconstructing the result from raw output logs.

### Bug Fixes

- **Keep optional observations from failing required checks** — Missing optional evidence no longer changes a successful required check into a failure, while genuine required failures still determine the final result.
- **Preserve client-side failures in the final report** — Locale and environment observation errors no longer disappear when a Playtest ends, making client-specific failures visible to both the AI agent and Dashboard.
- **Report real timeout durations and recover cleanly between runs** — Timed-out Raw Luau checks now retain their elapsed duration, and consecutive Playtest sessions no longer inherit stale interaction state from the previous run.
- **Record screen-size evidence without serialization errors** — Client checks can now return viewport dimensions as structured evidence without failing on Roblox vector values.

---
Automated release from weppy-roblox-mcp-private